### PR TITLE
Bring api into consistence with Javascript Regexp API + extra

### DIFF
--- a/lib/exec.cc
+++ b/lib/exec.cc
@@ -77,6 +77,8 @@ NAN_METHOD(WrappedRE2::Exec) {
 
 	Local<Array> result = Nan::New<Array>();
 
+	int indexOffset = re2->global ? re2->lastIndex : 0;
+
 	if (isBuffer) {
 		for (size_t i = 0, n = groups.size(); i < n; ++i) {
 			const StringPiece& item = groups[i];
@@ -84,7 +86,7 @@ NAN_METHOD(WrappedRE2::Exec) {
 				Nan::Set(result, i, Nan::CopyBuffer(item.data(), item.size()).ToLocalChecked());
 			}
 		}
-		Nan::Set(result, Nan::New("index").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(groups[0].data() - data)));
+		Nan::Set(result, Nan::New("index").ToLocalChecked(), Nan::New<Integer>(indexOffset + static_cast<int>(groups[0].data() - data)));
 	} else {
 		for (size_t i = 0, n = groups.size(); i < n; ++i) {
 			const StringPiece& item = groups[i];
@@ -92,7 +94,7 @@ NAN_METHOD(WrappedRE2::Exec) {
 				Nan::Set(result, i, Nan::New(item.data(), item.size()).ToLocalChecked());
 			}
 		}
-		Nan::Set(result, Nan::New("index").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(getUtf16Length(data, groups[0].data()))));
+		Nan::Set(result, Nan::New("index").ToLocalChecked(), Nan::New<Integer>(indexOffset + static_cast<int>(getUtf16Length(data, groups[0].data()))));
 	}
 
 	Nan::Set(result, Nan::New("input").ToLocalChecked(), info[0]);

--- a/lib/exec.cc
+++ b/lib/exec.cc
@@ -80,13 +80,17 @@ NAN_METHOD(WrappedRE2::Exec) {
 	if (isBuffer) {
 		for (size_t i = 0, n = groups.size(); i < n; ++i) {
 			const StringPiece& item = groups[i];
-			Nan::Set(result, i, Nan::CopyBuffer(item.data(), item.size()).ToLocalChecked());
+			if (item.data() != NULL) {
+				Nan::Set(result, i, Nan::CopyBuffer(item.data(), item.size()).ToLocalChecked());
+			}
 		}
 		Nan::Set(result, Nan::New("index").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(groups[0].data() - data)));
 	} else {
 		for (size_t i = 0, n = groups.size(); i < n; ++i) {
 			const StringPiece& item = groups[i];
-			Nan::Set(result, i, Nan::New(item.data(), item.size()).ToLocalChecked());
+			if (item.data() != NULL) {
+				Nan::Set(result, i, Nan::New(item.data(), item.size()).ToLocalChecked());
+			}
 		}
 		Nan::Set(result, Nan::New("index").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(getUtf16Length(data, groups[0].data()))));
 	}

--- a/lib/match.cc
+++ b/lib/match.cc
@@ -60,7 +60,9 @@ NAN_METHOD(WrappedRE2::Match) {
 	if (a.isBuffer) {
 		for (size_t i = 0, n = groups.size(); i < n; ++i) {
 			const StringPiece& item = groups[i];
-			Nan::Set(result, i, Nan::CopyBuffer(item.data(), item.size()).ToLocalChecked());
+			if (item.data() != NULL) {
+				Nan::Set(result, i, Nan::CopyBuffer(item.data(), item.size()).ToLocalChecked());
+			}
 		}
 		if (!re2->global) {
 			Nan::Set(result, Nan::New("index").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(groups[0].data() - a.data)));
@@ -69,7 +71,9 @@ NAN_METHOD(WrappedRE2::Match) {
 	} else {
 		for (size_t i = 0, n = groups.size(); i < n; ++i) {
 			const StringPiece& item = groups[i];
-			Nan::Set(result, i, Nan::New(item.data(), item.size()).ToLocalChecked());
+			if (item.data() != NULL) {
+				Nan::Set(result, i, Nan::New(item.data(), item.size()).ToLocalChecked());
+			}
 		}
 		if (!re2->global) {
 			Nan::Set(result, Nan::New("index").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(getUtf16Length(a.data, groups[0].data()))));

--- a/lib/new.cc
+++ b/lib/new.cc
@@ -8,6 +8,7 @@ using std::string;
 using std::vector;
 
 using v8::Local;
+using v8::MaybeLocal;
 using v8::RegExp;
 using v8::String;
 using v8::Value;
@@ -190,6 +191,13 @@ NAN_METHOD(WrappedRE2::New) {
 	RE2::Options options;
 	options.set_case_sensitive(!ignoreCase);
 	options.set_one_line(!multiline);
+
+	if (info.Length() >= 3 && info[2]->IsObject()) {
+		MaybeLocal<Value> max_mem = info[2]->ToObject()->Get(Nan::New("max_mem").ToLocalChecked());
+		if (!max_mem.IsEmpty()) {
+			options.set_max_mem(max_mem.ToLocalChecked()->IntegerValue());
+		}
+	}
 
 	// create and return an object
 


### PR DESCRIPTION
1. Javascript API which this library mimics returns undefined for non-matched groups, this library was returning empty string which is indistinguishable from zero-width capture.

2. Javascript API sets "index" field on match result relative to the start of the whole input (basically, adds lastIndex), this library wasn't adding lastIndex.

3. Allow setting max_mem option