### PR TITLE
.travis.yml: Add Node version 4 (still LTS) and remove version 7 (EOL'd)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: false
 language: node_js
 
 node_js:
+  - "4"
   - "6"
-  - "7"
   - "8"
   - "9"
 


### PR DESCRIPTION
Just noticed that your ".travis.yml" includes Node version 7, which is EOL'd, but doesn't include Node version 4, which has a few more months left of support.

I wasn't sure if this was intentional or an oversight.  If it's intentional, ignore this pull request :-)