### PR TITLE
binding.gyp: Fix macOS build error by setting MACOSX_DEPLOYMENT_TARGET=10.7

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -56,6 +56,7 @@
         "vendor"
       ],
       "xcode_settings": {
+        "MACOSX_DEPLOYMENT_TARGET": "10.7",
         "CLANG_CXX_LANGUAGE_STANDARD": "c++11",
         "CLANG_CXX_LIBRARY": "libc++",
         "OTHER_CFLAGS": [


### PR DESCRIPTION
I somehow screwed up the original pull request (#14) so I'm remaking it.  Sorry!