### PR TITLE
Fix accessors for prototype

### DIFF
--- a/lib/accessors.cc
+++ b/lib/accessors.cc
@@ -5,36 +5,65 @@ using v8::Integer;
 
 
 NAN_GETTER(WrappedRE2::GetSource) {
+	if (!WrappedRE2::HasInstance(info.This())) {
+		info.GetReturnValue().Set(Nan::New("(?:)").ToLocalChecked());
+		return;
+	}
+
 	WrappedRE2* re2 = Nan::ObjectWrap::Unwrap<WrappedRE2>(info.This());
 	info.GetReturnValue().Set(Nan::New(re2->regexp.pattern()).ToLocalChecked());
 }
 
 
 NAN_GETTER(WrappedRE2::GetGlobal) {
+	if (!WrappedRE2::HasInstance(info.This())) {
+		info.GetReturnValue().SetUndefined();
+		return;
+	}
+
 	WrappedRE2* re2 = Nan::ObjectWrap::Unwrap<WrappedRE2>(info.This());
 	info.GetReturnValue().Set(re2->global);
 }
 
 
 NAN_GETTER(WrappedRE2::GetIgnoreCase) {
+	if (!WrappedRE2::HasInstance(info.This())) {
+		info.GetReturnValue().SetUndefined();
+		return;
+	}
+
 	WrappedRE2* re2 = Nan::ObjectWrap::Unwrap<WrappedRE2>(info.This());
 	info.GetReturnValue().Set(re2->ignoreCase);
 }
 
 
 NAN_GETTER(WrappedRE2::GetMultiline) {
+	if (!WrappedRE2::HasInstance(info.This())) {
+		info.GetReturnValue().SetUndefined();
+		return;
+	}
+
 	WrappedRE2* re2 = Nan::ObjectWrap::Unwrap<WrappedRE2>(info.This());
 	info.GetReturnValue().Set(re2->multiline);
 }
 
 
 NAN_GETTER(WrappedRE2::GetLastIndex) {
+	if (!WrappedRE2::HasInstance(info.This())) {
+		info.GetReturnValue().SetUndefined();
+		return;
+	}
+
 	WrappedRE2* re2 = Nan::ObjectWrap::Unwrap<WrappedRE2>(info.This());
 	info.GetReturnValue().Set(static_cast<int>(re2->lastIndex));
 }
 
 
 NAN_SETTER(WrappedRE2::SetLastIndex) {
+	if (!WrappedRE2::HasInstance(info.This())) {
+		return Nan::ThrowTypeError("Cannot set lastIndex of an invalid RE2 object.");
+	}
+
 	WrappedRE2* re2 = Nan::ObjectWrap::Unwrap<WrappedRE2>(info.This());
 	if (value->IsNumber()) {
 		int n = value->NumberValue();

--- a/lib/addon.cc
+++ b/lib/addon.cc
@@ -10,7 +10,8 @@ using v8::ObjectTemplate;
 using v8::String;
 
 
-Nan::Persistent<Function> WrappedRE2::constructor;
+Nan::Persistent<Function>         WrappedRE2::constructor;
+Nan::Persistent<FunctionTemplate> WrappedRE2::ctorTemplate;
 
 
 static NAN_METHOD(GetUtf8Length) {
@@ -59,6 +60,7 @@ void WrappedRE2::Initialize(Handle<Object> exports, Handle<Object> module) {
 	Nan::Export(fun, "getUtf8Length",  GetUtf8Length);
 	Nan::Export(fun, "getUtf16Length", GetUtf16Length);
 	constructor.Reset(fun);
+	ctorTemplate.Reset(tpl);
 
 	// return constructor as module's export
 	Nan::Set(module, Nan::New("exports").ToLocalChecked(), fun);

--- a/lib/wrapped_re2.h
+++ b/lib/wrapped_re2.h
@@ -10,7 +10,9 @@
 
 using v8::Function;
 using v8::Handle;
+using v8::Local;
 using v8::Object;
+using v8::FunctionTemplate;
 
 using re2::RE2;
 using re2::StringPiece;
@@ -43,10 +45,15 @@ class WrappedRE2 : public Nan::ObjectWrap {
 		static NAN_METHOD(Search);
 		static NAN_METHOD(Split);
 
-		static Nan::Persistent<Function>	constructor;
+		static Nan::Persistent<Function>			constructor;
+		static Nan::Persistent<FunctionTemplate>	ctorTemplate;
 
 	public:
 		static void Initialize(Handle<Object> exports, Handle<Object> module);
+
+		static inline bool HasInstance(Local<Object> object) {
+			return Nan::New(ctorTemplate)->HasInstance(object);
+		}
 
 		RE2		regexp;
 		bool	global;

--- a/tests/test_prototype.js
+++ b/tests/test_prototype.js
@@ -1,0 +1,20 @@
+"use strict";
+
+
+var unit = require("heya-unit");
+var RE2  = require("../re2");
+
+
+// tests
+
+unit.add(module, [
+	function test_prototype(t) {
+		"use strict";
+
+		eval(t.TEST("RE2.prototype.source === '(?:)'"));
+		eval(t.TEST("RE2.prototype.global === false"));
+		eval(t.TEST("RE2.prototype.ignoreCase === false"));
+		eval(t.TEST("RE2.prototype.multiline === false"));
+		eval(t.TEST("RE2.prototype.lastIndex === 0'"));
+	}
+]);

--- a/tests/test_prototype.js
+++ b/tests/test_prototype.js
@@ -15,6 +15,6 @@ unit.add(module, [
 		eval(t.TEST("RE2.prototype.global === undefined"));
 		eval(t.TEST("RE2.prototype.ignoreCase === undefined"));
 		eval(t.TEST("RE2.prototype.multiline === undefined"));
-		eval(t.TEST("RE2.prototype.lastIndex === undefined'"));
+		eval(t.TEST("RE2.prototype.lastIndex === undefined"));
 	}
 ]);

--- a/tests/test_prototype.js
+++ b/tests/test_prototype.js
@@ -12,9 +12,9 @@ unit.add(module, [
 		"use strict";
 
 		eval(t.TEST("RE2.prototype.source === '(?:)'"));
-		eval(t.TEST("RE2.prototype.global === false"));
-		eval(t.TEST("RE2.prototype.ignoreCase === false"));
-		eval(t.TEST("RE2.prototype.multiline === false"));
-		eval(t.TEST("RE2.prototype.lastIndex === 0'"));
+		eval(t.TEST("RE2.prototype.global === undefined"));
+		eval(t.TEST("RE2.prototype.ignoreCase === undefined"));
+		eval(t.TEST("RE2.prototype.multiline === undefined"));
+		eval(t.TEST("RE2.prototype.lastIndex === undefined'"));
 	}
 ]);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -3,16 +3,17 @@
 
 var unit = require("heya-unit");
 
-var testGeneral  = require("./test_general");
-var testExec     = require("./test_exec");
-var testTest     = require("./test_test");
-var testToString = require("./test_toString");
-var testMatch    = require("./test_match");
-var testReplace  = require("./test_replace");
-var testSearch   = require("./test_search");
-var testSplit    = require("./test_split");
-var testInvalid  = require("./test_invalid");
-var testSplit    = require("./test_symbols");
+var testGeneral   = require("./test_general");
+var testExec      = require("./test_exec");
+var testTest      = require("./test_test");
+var testToString  = require("./test_toString");
+var testMatch     = require("./test_match");
+var testReplace   = require("./test_replace");
+var testSearch    = require("./test_search");
+var testSplit     = require("./test_split");
+var testInvalid   = require("./test_invalid");
+var testSymbols   = require("./test_symbols");
+var testPrototype = require("./test_prototype");
 
 
 unit.run();


### PR DESCRIPTION
Adds well-defined values to `RE2.prototype`'s properties, which until now returned whatever happened to be behind an invalid pointer, or crashed trying (see also #19).

The values of most of the properties are taken from `RegExp.prototype` as of Node v8, except for `lastIndex` which doesn't exist there.