### PR TITLE
Fix constructor function call with invalid parameters

### DIFF
--- a/lib/new.cc
+++ b/lib/new.cc
@@ -100,8 +100,11 @@ NAN_METHOD(WrappedRE2::New) {
 		for (size_t i = 0, n = info.Length(); i < n; ++i) {
 			parameters[i] = info[i];
 		}
-		info.GetReturnValue().Set(Nan::NewInstance(Nan::New<Function>(constructor),
-			parameters.size(), &parameters[0]).ToLocalChecked());
+		auto newObject = Nan::NewInstance(Nan::New<Function>(constructor),
+			parameters.size(), &parameters[0]);
+		if (!newObject.IsEmpty()) {
+			info.GetReturnValue().Set(newObject.ToLocalChecked());
+		}
 		return;
 	}
 

--- a/tests/test_general.js
+++ b/tests/test_general.js
@@ -75,6 +75,13 @@ unit.add(module, [
 		} catch(e) {
 			eval(t.TEST("e instanceof TypeError"));
 		}
+
+		try {
+			var re = RE2();
+			t.test(false); // shouldn't be here
+		} catch(e) {
+			eval(t.TEST("e instanceof TypeError"));
+		}
 	},
 	function test_generalIn(t) {
 		"use strict";


### PR DESCRIPTION
Fixes calling the constructor as a function with invalid parameters, so that it throws the same exception as calling it with `new`, instead of crashing Node (see also #25).