### PR TITLE
Fix RE2.getUtf8Length and RE2.getUtf16Length

### DIFF
--- a/lib/wrapped_re2.h
+++ b/lib/wrapped_re2.h
@@ -71,7 +71,7 @@ inline size_t getUtf8Length(const uint16_t* from, const uint16_t* to) {
 		uint16_t ch = *from++;
 		if (ch <= 0x7F) ++n;
 		else if (ch <= 0x7FF) n += 2;
-		else if (0xD800 <= ch && ch <= 0xDFFF) n += 4;
+		else if (0xD800 <= ch && ch <= 0xDFFF) { n += 4; if (from == to) break; from++; }
 		else if (ch < 0xFFFF) n += 3;
 		else n += 4;
 	}
@@ -88,14 +88,25 @@ inline size_t getUtf16Length(const char* from, const char* to) {
 			} else {
 				if (ch < 0xE0) {
 					from += 2;
+					if (from == to + 1) {
+						++n;
+						break;
+					}
 				} else {
 					from += 3;
+					if (from == to + 1 || from == to + 2) {
+						++n;
+						break;
+					}
 				}
 			}
 			++n;
 		} else {
 			from += 4;
 			n += 2;
+			if (from == to + 1 || from == to + 2 || from == to + 3) {
+				break;
+			}
 		}
 	}
 	return n;

--- a/tests/test_general.js
+++ b/tests/test_general.js
@@ -175,6 +175,25 @@ unit.add(module, [
 		var b = new Buffer(s);
 		eval(t.TEST("b.length === 13"));
 		eval(t.TEST("RE2.getUtf16Length(b) === 7"));
+
+		var s2 = "\u{1F603}";
+
+		eval(t.TEST("s2.length === 2"));
+		eval(t.TEST("RE2.getUtf8Length(s2) === 4"));
+
+		var b2 = new Buffer(s2);
+		eval(t.TEST("b2.length === 4"));
+		eval(t.TEST("RE2.getUtf16Length(b2) === 2"));
+
+		var s3 = "\uD83D";
+
+		eval(t.TEST("s3.length === 1"));
+		eval(t.TEST("RE2.getUtf8Length(s3) === 4"));
+
+		var b3 = new Buffer([ 0xF0 ]);
+
+		eval(t.TEST("b3.length === 1"));
+		eval(t.TEST("RE2.getUtf16Length(b3) === 2"));
 	},
 	function test_sourceTranslation(t) {
 		"use strict";


### PR DESCRIPTION
Fixes a counting error in `getUtf8Length` and a segmentation fault in `getUtf16Length` (see also #30 and #31).