### PR TITLE
Add support for sticky (/y)

### DIFF
--- a/lib/accessors.cc
+++ b/lib/accessors.cc
@@ -48,6 +48,17 @@ NAN_GETTER(WrappedRE2::GetMultiline) {
 }
 
 
+NAN_GETTER(WrappedRE2::GetSticky) {
+	if (!WrappedRE2::HasInstance(info.This())) {
+		info.GetReturnValue().SetUndefined();
+		return;
+	}
+
+	WrappedRE2* re2 = Nan::ObjectWrap::Unwrap<WrappedRE2>(info.This());
+	info.GetReturnValue().Set(re2->sticky);
+}
+
+
 NAN_GETTER(WrappedRE2::GetLastIndex) {
 	if (!WrappedRE2::HasInstance(info.This())) {
 		info.GetReturnValue().SetUndefined();

--- a/lib/addon.cc
+++ b/lib/addon.cc
@@ -54,6 +54,7 @@ void WrappedRE2::Initialize(Handle<Object> exports, Handle<Object> module) {
 	Nan::SetAccessor(proto, Nan::New("global").ToLocalChecked(),     GetGlobal);
 	Nan::SetAccessor(proto, Nan::New("ignoreCase").ToLocalChecked(), GetIgnoreCase);
 	Nan::SetAccessor(proto, Nan::New("multiline").ToLocalChecked(),  GetMultiline);
+	Nan::SetAccessor(proto, Nan::New("sticky").ToLocalChecked(),     GetSticky);
 	Nan::SetAccessor(proto, Nan::New("lastIndex").ToLocalChecked(),  GetLastIndex, SetLastIndex);
 
 	Local<Function> fun = Nan::GetFunction(tpl).ToLocalChecked();

--- a/lib/addon.cc
+++ b/lib/addon.cc
@@ -1,4 +1,5 @@
 #include "./wrapped_re2.h"
+#include "./util.h"
 
 #include <node_buffer.h>
 
@@ -15,7 +16,11 @@ Nan::Persistent<FunctionTemplate> WrappedRE2::ctorTemplate;
 
 
 static NAN_METHOD(GetUtf8Length) {
-	String::Value s(info[0]->ToString());
+	ToStringHelper<String::Value> ms(info[0]);
+	if (ms.IsEmpty()) {
+		return;
+	}
+	const String::Value& s = ms.Unwrap();
 	info.GetReturnValue().Set(static_cast<int>(getUtf8Length(*s, *s + s.length())));
 }
 

--- a/lib/exec.cc
+++ b/lib/exec.cc
@@ -54,6 +54,9 @@ NAN_METHOD(WrappedRE2::Exec) {
 	vector<char> buffer;
 
 	StrVal str(info[0]);
+	if (str.IsEmpty()) {
+		return;
+	}
 
 	Utf8LastIndexGuard guard(re2, info[0], str);
 

--- a/lib/exec.cc
+++ b/lib/exec.cc
@@ -1,4 +1,5 @@
 #include "./wrapped_re2.h"
+#include "./util.h"
 
 #include <vector>
 
@@ -13,6 +14,33 @@ using v8::Local;
 using v8::String;
 
 
+bool WrappedRE2::DoExec(const StringPiece& input, StringPiece& match, size_t numberOfGroups) {
+	if (global || sticky) {
+		if (lastIndex >= input.size()) {
+			lastIndex = 0;
+
+			return false;
+		}
+
+		bool result = regexp.Match(input, lastIndex, input.size(), sticky ? RE2::ANCHOR_START : RE2::UNANCHORED, &match, numberOfGroups);
+		lastIndex = result ? match.data() - input.data() + match.size() : 0;
+
+		return result;
+	} else {
+		return regexp.Match(input, 0, input.size(), RE2::UNANCHORED, &match, numberOfGroups);
+	}
+}
+
+
+bool WrappedRE2::DoExec(const StringPiece& input, vector<StringPiece>& groups, bool autoResizeGroups) {
+	if (autoResizeGroups) {
+		groups.resize(regexp.NumberOfCapturingGroups() + 1);
+	}
+
+	return DoExec(input, groups[0], groups.size());
+}
+
+
 NAN_METHOD(WrappedRE2::Exec) {
 
 	// unpack arguments
@@ -25,50 +53,15 @@ NAN_METHOD(WrappedRE2::Exec) {
 
 	vector<char> buffer;
 
-	char*  data;
-	size_t size, lastIndex = 0;
-	bool   isBuffer = false;
+	StrVal str(info[0]);
 
-	if (node::Buffer::HasInstance(info[0])) {
-		isBuffer = true;
-		size = node::Buffer::Length(info[0]);
-		if (re2->global) {
-			if (re2->lastIndex > size) {
-				re2->lastIndex = 0;
-				info.GetReturnValue().SetNull();
-				return;
-			}
-			lastIndex = re2->lastIndex;
-		}
-		data = node::Buffer::Data(info[0]);
-	} else {
-		if (re2->global && re2->lastIndex) {
-			String::Value s(info[0]->ToString());
-			if (re2->lastIndex > s.length()) {
-				re2->lastIndex = 0;
-				info.GetReturnValue().SetNull();
-				return;
-			}
-			Local<String> t(Nan::New(*s + re2->lastIndex).ToLocalChecked());
-			buffer.resize(t->Utf8Length() + 1);
-			t->WriteUtf8(&buffer[0]);
-		} else {
-			Local<String> t(info[0]->ToString());
-			buffer.resize(t->Utf8Length() + 1);
-			t->WriteUtf8(&buffer[0]);
-		}
-		size = buffer.size() - 1;
-		data = &buffer[0];
-	}
+	Utf8LastIndexGuard guard(re2, info[0], str);
 
 	// actual work
 
-	vector<StringPiece> groups(re2->regexp.NumberOfCapturingGroups() + 1);
+	vector<StringPiece> groups;
 
-	if (!re2->regexp.Match(StringPiece(data, size), lastIndex, size, RE2::UNANCHORED, &groups[0], groups.size())) {
-		if (re2->global) {
-			re2->lastIndex = 0;
-		}
+	if (!re2->DoExec(str, groups)) {
 		info.GetReturnValue().SetNull();
 		return;
 	}
@@ -77,9 +70,7 @@ NAN_METHOD(WrappedRE2::Exec) {
 
 	Local<Array> result = Nan::New<Array>();
 
-	int indexOffset = re2->global ? re2->lastIndex : 0;
-
-	if (isBuffer) {
+	if (str.isBuffer) {
 		for (size_t i = 0, n = groups.size(); i < n; ++i) {
 			const StringPiece& item = groups[i];
 			if (item.data() != NULL) {
@@ -87,7 +78,7 @@ NAN_METHOD(WrappedRE2::Exec) {
 			}
 		}
 		Nan::Set(result, Nan::New("index").ToLocalChecked(), Nan::New<Integer>(
-			indexOffset + static_cast<int>(groups[0].data() - data)));
+			static_cast<int>(groups[0].data() - str.data)));
 	} else {
 		for (size_t i = 0, n = groups.size(); i < n; ++i) {
 			const StringPiece& item = groups[i];
@@ -96,15 +87,10 @@ NAN_METHOD(WrappedRE2::Exec) {
 			}
 		}
 		Nan::Set(result, Nan::New("index").ToLocalChecked(), Nan::New<Integer>(
-			indexOffset + static_cast<int>(getUtf16Length(data, groups[0].data()))));
+			static_cast<int>(getUtf16Length(str.data, groups[0].data()))));
 	}
 
 	Nan::Set(result, Nan::New("input").ToLocalChecked(), info[0]);
-
-	if (re2->global) {
-		re2->lastIndex += isBuffer ? groups[0].data() - data + groups[0].size() - lastIndex :
-			getUtf16Length(data, groups[0].data() + groups[0].size());
-	}
 
 	info.GetReturnValue().Set(result);
 }

--- a/lib/match.cc
+++ b/lib/match.cc
@@ -27,7 +27,7 @@ NAN_METHOD(WrappedRE2::Match) {
 		return;
 	}
 
-	Utf8LastIndexGuard guard(re2, info[0], str);
+	Utf8LastIndexGuard guard(re2, str);
 
 	vector<StringPiece> groups;
 
@@ -68,7 +68,7 @@ NAN_METHOD(WrappedRE2::Match) {
 			}
 		}
 		if (!re2->global) {
-			Nan::Set(result, Nan::New("index").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(groups[0].data() - str.data)));
+			Nan::Set(result, Nan::New("index").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(groups[0].data() - str.data + str.startIndex)));
 			Nan::Set(result, Nan::New("input").ToLocalChecked(), info[0]);
 		}
 	} else {
@@ -79,7 +79,7 @@ NAN_METHOD(WrappedRE2::Match) {
 			}
 		}
 		if (!re2->global) {
-			Nan::Set(result, Nan::New("index").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(getUtf16Length(str.data, groups[0].data()))));
+			Nan::Set(result, Nan::New("index").ToLocalChecked(), Nan::New<Integer>(static_cast<int>(getUtf16Length(str.data, groups[0].data()) + str.startIndex)));
 			Nan::Set(result, Nan::New("input").ToLocalChecked(), info[0]);
 		}
 	}

--- a/lib/match.cc
+++ b/lib/match.cc
@@ -23,6 +23,9 @@ NAN_METHOD(WrappedRE2::Match) {
 	}
 
 	StrVal str(info[0]);
+	if (str.IsEmpty()) {
+		return;
+	}
 
 	Utf8LastIndexGuard guard(re2, info[0], str);
 

--- a/lib/new.cc
+++ b/lib/new.cc
@@ -142,6 +142,7 @@ NAN_METHOD(WrappedRE2::New) {
 	bool ignoreCase = false;
 	bool multiline = false;
 	bool global = false;
+	bool sticky = false;
 
 	if (info.Length() > 1) {
 		if (info[1]->IsString()) {
@@ -164,6 +165,9 @@ NAN_METHOD(WrappedRE2::New) {
 					break;
 				case 'g':
 					global = true;
+					break;
+				case 'y':
+					sticky = true;
 					break;
 			}
 		}
@@ -188,6 +192,7 @@ NAN_METHOD(WrappedRE2::New) {
 		ignoreCase = bool(flags & RegExp::kIgnoreCase);
 		multiline  = bool(flags & RegExp::kMultiline);
 		global     = bool(flags & RegExp::kGlobal);
+		sticky     = bool(flags & RegExp::kSticky);
 	} else if (info[0]->IsObject() && !info[0]->IsString()) {
 		WrappedRE2* re2 = NULL;
 		auto object = info[0]->ToObject();
@@ -205,6 +210,7 @@ NAN_METHOD(WrappedRE2::New) {
 			ignoreCase = re2->ignoreCase;
 			multiline  = re2->multiline;
 			global     = re2->global;
+			sticky     = re2->sticky;
 		}
 	} else if (info[0]->IsString()) {
 		Local<String> t(info[0]->ToString());
@@ -230,7 +236,7 @@ NAN_METHOD(WrappedRE2::New) {
 	options.set_one_line(!multiline);
 	options.set_log_errors(false); // inappropriate when embedding
 
-	WrappedRE2* re2 = new WrappedRE2(StringPiece(data, size), options, global, ignoreCase, multiline);
+	WrappedRE2* re2 = new WrappedRE2(StringPiece(data, size), options, global, ignoreCase, multiline, sticky);
 	if (!re2->regexp.ok()) {
 		delete re2;
 		return Nan::ThrowSyntaxError("Unsupported regular expression features (check for backreferences, lookahead assertions).");

--- a/lib/search.cc
+++ b/lib/search.cc
@@ -21,7 +21,14 @@ NAN_METHOD(WrappedRE2::Search) {
 
 	StringPiece match;
 
-	if (re2->regexp.Match(a, 0, a.size, RE2::UNANCHORED, &match, 1)) {
+	size_t lastIndex = re2->lastIndex;
+	re2->lastIndex = 0;
+
+	bool found = re2->DoExec(a, match);
+
+	re2->lastIndex = lastIndex;
+
+	if (found) {
 		info.GetReturnValue().Set(static_cast<int>(a.isBuffer ? match.data() - a.data :
 			getUtf16Length(a.data, match.data())));
 		return;

--- a/lib/search.cc
+++ b/lib/search.cc
@@ -16,6 +16,9 @@ NAN_METHOD(WrappedRE2::Search) {
 	}
 
 	StrVal a(info[0]);
+	if (a.IsEmpty()) {
+		return;
+	}
 
 	// actual work
 

--- a/lib/split.cc
+++ b/lib/split.cc
@@ -29,6 +29,9 @@ NAN_METHOD(WrappedRE2::Split) {
 	}
 
 	StrVal a(info[0]);
+	if (a.IsEmpty()) {
+		return;
+	}
 	StringPiece str(a);
 
 	size_t limit = numeric_limits<size_t>::max();

--- a/lib/test.cc
+++ b/lib/test.cc
@@ -1,4 +1,5 @@
 #include "./wrapped_re2.h"
+#include "./util.h"
 
 #include <vector>
 
@@ -23,56 +24,12 @@ NAN_METHOD(WrappedRE2::Test) {
 
 	vector<char> buffer;
 
-	char*  data;
-	size_t size, lastIndex = 0;
-	bool   isBuffer = false;
+	StrVal str(info[0]);
 
-	if (node::Buffer::HasInstance(info[0])) {
-		isBuffer = true;
-		size = node::Buffer::Length(info[0]);
-		if (re2->global) {
-			if (re2->lastIndex > size) {
-				re2->lastIndex = 0;
-				info.GetReturnValue().Set(false);
-				return;
-			}
-			lastIndex = re2->lastIndex;
-		}
-		data = node::Buffer::Data(info[0]);
-	} else {
-		if (re2->global && re2->lastIndex) {
-			String::Value s(info[0]->ToString());
-			if (re2->lastIndex > s.length()) {
-				re2->lastIndex = 0;
-				info.GetReturnValue().Set(false);
-				return;
-			}
-			Local<String> t(Nan::New(*s + re2->lastIndex).ToLocalChecked());
-			buffer.resize(t->Utf8Length() + 1);
-			t->WriteUtf8(&buffer[0]);
-		} else {
-			Local<String> t(info[0]->ToString());
-			buffer.resize(t->Utf8Length() + 1);
-			t->WriteUtf8(&buffer[0]);
-		}
-		size = buffer.size() - 1;
-		data = &buffer[0];
-	}
+	Utf8LastIndexGuard guard(re2, info[0], str);
 
 	// actual work
 
-	if (re2->global) {
-		StringPiece match;
-		if (re2->regexp.Match(StringPiece(data, size), lastIndex, size, RE2::UNANCHORED, &match, 1)) {
-			re2->lastIndex += isBuffer ? match.data() - data + match.size() - lastIndex :
-				getUtf16Length(data, match.data() + match.size());
-			info.GetReturnValue().Set(true);
-			return;
-		}
-		re2->lastIndex = 0;
-		info.GetReturnValue().Set(false);
-		return;
-	}
-
-	info.GetReturnValue().Set(re2->regexp.Match(StringPiece(data, size), 0, size, RE2::UNANCHORED, NULL, 0));
+	StringPiece match;
+	info.GetReturnValue().Set(re2->DoExec(str, match));
 }

--- a/lib/test.cc
+++ b/lib/test.cc
@@ -24,15 +24,19 @@ NAN_METHOD(WrappedRE2::Test) {
 
 	vector<char> buffer;
 
-	StrVal str(info[0]);
+	StrVal str(info[0], re2->GetStartIndexHint());
 	if (str.IsEmpty()) {
 		return;
 	}
 
-	Utf8LastIndexGuard guard(re2, info[0], str);
+	Utf8LastIndexGuard guard(re2, str);
 
 	// actual work
 
 	StringPiece match;
-	info.GetReturnValue().Set(re2->DoExec(str, match));
+	bool result = re2->DoExec(str, match);
+	if (!result) {
+		guard.DontRestore();
+	}
+	info.GetReturnValue().Set(result);
 }

--- a/lib/test.cc
+++ b/lib/test.cc
@@ -25,6 +25,9 @@ NAN_METHOD(WrappedRE2::Test) {
 	vector<char> buffer;
 
 	StrVal str(info[0]);
+	if (str.IsEmpty()) {
+		return;
+	}
 
 	Utf8LastIndexGuard guard(re2, info[0], str);
 

--- a/lib/to_string.cc
+++ b/lib/to_string.cc
@@ -32,6 +32,9 @@ NAN_METHOD(WrappedRE2::ToString) {
 	if (re2->multiline) {
 		buffer += "m";
 	}
+	if (re2->sticky) {
+		buffer += "y";
+	}
 
 	info.GetReturnValue().Set(Nan::New(buffer).ToLocalChecked());
 }

--- a/lib/util.cc
+++ b/lib/util.cc
@@ -21,3 +21,20 @@ StrVal::StrVal(const Local<Value>& arg) : data(NULL), size(0), isBuffer(false) {
 		t->WriteUtf8(data);
 	}
 }
+
+
+Utf8LastIndexGuard::Utf8LastIndexGuard(WrappedRE2* re2, const Local<Value>& utf16Input, const StrVal& utf8Input) : re2_(re2), utf8Input_(utf8Input) {
+	if (!re2 || (!re2->global && !re2->sticky) || utf8Input.isBuffer) {
+		re2_ = NULL;
+	} else {
+		String::Value inputValue(utf16Input->ToString());
+		re2->lastIndex = getUtf8Length(*inputValue, *inputValue + ((re2->lastIndex < inputValue.length()) ? re2->lastIndex : inputValue.length()));
+	}
+}
+
+
+Utf8LastIndexGuard::~Utf8LastIndexGuard() {
+	if (re2_) {
+		re2_->lastIndex = getUtf16Length(utf8Input_.data, utf8Input_.data + ((re2_->lastIndex < utf8Input_.size) ? re2_->lastIndex : utf8Input_.size));
+	}
+}

--- a/lib/util.h
+++ b/lib/util.h
@@ -15,9 +15,39 @@ struct StrVal {
 	StrVal() : data(NULL), size(0), isBuffer(false) {}
 	StrVal(const v8::Local<v8::Value>& arg);
 
+	inline bool IsEmpty() const { return data == NULL; }
+
 	operator StringPiece () { return StringPiece(data, size); }
 	operator const StringPiece () const { return StringPiece(data, size); }
 };
+
+
+template<typename T>
+class ToStringHelper {
+		T* value_;
+
+	public:
+		inline ToStringHelper(const v8::Local<v8::Value>& value) : value_(NULL) {
+			v8::MaybeLocal<v8::String> str(value->ToString(v8::Isolate::GetCurrent()->GetCurrentContext()));
+			if (!str.IsEmpty()) {
+				value_ = new T(str.ToLocalChecked());
+			}
+		}
+		ToStringHelper(const ToStringHelper&) = delete;
+		inline ~ToStringHelper() {
+			if (value_) {
+				delete value_;
+			}
+		}
+
+		ToStringHelper& operator =(const ToStringHelper&) = delete;
+
+		inline bool IsEmpty() const { return value_ == NULL; }
+
+		inline T& Unwrap() { return *value_; }
+		inline const T& Unwrap() const { return *value_; }
+};
+
 
 class Utf8LastIndexGuard {
 		WrappedRE2*   re2_;

--- a/lib/util.h
+++ b/lib/util.h
@@ -26,13 +26,13 @@ struct StrVal {
 
 template<typename T>
 class ToStringHelper {
+		v8::MaybeLocal<v8::String> str_;
 		T* value_;
 
 	public:
-		inline ToStringHelper(const v8::Local<v8::Value>& value) : value_(NULL) {
-			v8::MaybeLocal<v8::String> str(value->ToString(v8::Isolate::GetCurrent()->GetCurrentContext()));
-			if (!str.IsEmpty()) {
-				value_ = new T(str.ToLocalChecked());
+		inline ToStringHelper(const v8::Local<v8::Value>& value) : str_(value->ToString(v8::Isolate::GetCurrent()->GetCurrentContext())), value_(NULL) {
+			if (!str_.IsEmpty()) {
+				value_ = new T(str_.ToLocalChecked());
 			}
 		}
 		ToStringHelper(const ToStringHelper&) = delete;

--- a/lib/util.h
+++ b/lib/util.h
@@ -10,10 +10,12 @@ struct StrVal {
 	std::vector<char> buffer;
 	char*  data;
 	size_t size;
+	size_t startIndex;
 	bool   isBuffer;
+	v8::MaybeLocal<v8::String> original;
 
-	StrVal() : data(NULL), size(0), isBuffer(false) {}
-	StrVal(const v8::Local<v8::Value>& arg);
+	StrVal() : data(NULL), size(0), startIndex(0), isBuffer(false), original() {}
+	StrVal(const v8::Local<v8::Value>& arg, size_t startIndexHint = 0);
 
 	inline bool IsEmpty() const { return data == NULL; }
 
@@ -51,14 +53,16 @@ class ToStringHelper {
 
 class Utf8LastIndexGuard {
 		WrappedRE2*   re2_;
-		const StrVal& utf8Input_;
+		const StrVal& input_;
 
 	public:
-		Utf8LastIndexGuard(WrappedRE2* re2, const v8::Local<v8::Value>& utf16Input, const StrVal& utf8Input);
+		Utf8LastIndexGuard(WrappedRE2* re2, StrVal& input);
 		Utf8LastIndexGuard(const Utf8LastIndexGuard&) = delete;
 		~Utf8LastIndexGuard();
 
 		Utf8LastIndexGuard& operator =(const Utf8LastIndexGuard&) = delete;
+
+		inline void DontRestore() { re2_ = NULL; }
 };
 
 

--- a/lib/util.h
+++ b/lib/util.h
@@ -19,5 +19,17 @@ struct StrVal {
 	operator const StringPiece () const { return StringPiece(data, size); }
 };
 
+class Utf8LastIndexGuard {
+		WrappedRE2*   re2_;
+		const StrVal& utf8Input_;
+
+	public:
+		Utf8LastIndexGuard(WrappedRE2* re2, const v8::Local<v8::Value>& utf16Input, const StrVal& utf8Input);
+		Utf8LastIndexGuard(const Utf8LastIndexGuard&) = delete;
+		~Utf8LastIndexGuard();
+
+		Utf8LastIndexGuard& operator =(const Utf8LastIndexGuard&) = delete;
+};
+
 
 #endif

--- a/lib/wrapped_re2.h
+++ b/lib/wrapped_re2.h
@@ -22,8 +22,8 @@ class WrappedRE2 : public Nan::ObjectWrap {
 
 	private:
 		WrappedRE2(const StringPiece& pattern, const RE2::Options& options,
-			const bool& g, const bool& i, const bool& m) : regexp(pattern, options),
-				global(g), ignoreCase(i), multiline(m), lastIndex(0) {}
+			const bool& g, const bool& i, const bool& m, const bool& y) : regexp(pattern, options),
+				global(g), ignoreCase(i), multiline(m), sticky(y), lastIndex(0) {}
 
 		static NAN_METHOD(New);
 		static NAN_METHOD(ToString);
@@ -32,6 +32,7 @@ class WrappedRE2 : public Nan::ObjectWrap {
 		static NAN_GETTER(GetGlobal);
 		static NAN_GETTER(GetIgnoreCase);
 		static NAN_GETTER(GetMultiline);
+		static NAN_GETTER(GetSticky);
 		static NAN_GETTER(GetLastIndex);
 		static NAN_SETTER(SetLastIndex);
 
@@ -59,7 +60,11 @@ class WrappedRE2 : public Nan::ObjectWrap {
 		bool	global;
 		bool	ignoreCase;
 		bool	multiline;
+		bool	sticky;
 		size_t	lastIndex;
+
+		bool DoExec(const StringPiece& input, StringPiece& match, size_t numberOfGroups = 1);
+		bool DoExec(const StringPiece& input, std::vector<StringPiece>& groups, bool autoResizeGroups = true);
 };
 
 

--- a/lib/wrapped_re2.h
+++ b/lib/wrapped_re2.h
@@ -22,8 +22,8 @@ class WrappedRE2 : public Nan::ObjectWrap {
 
 	private:
 		WrappedRE2(const StringPiece& pattern, const RE2::Options& options,
-			const bool& g, const bool& i, const bool& m, const bool& y) : regexp(pattern, options),
-				global(g), ignoreCase(i), multiline(m), sticky(y), lastIndex(0) {}
+			const bool& g, const bool& i, const bool& m, const bool& y, const bool& scb) : regexp(pattern, options),
+				global(g), ignoreCase(i), multiline(m), sticky(y), safeToCutBeginning(scb), lastIndex(0) {}
 
 		static NAN_METHOD(New);
 		static NAN_METHOD(ToString);
@@ -61,10 +61,13 @@ class WrappedRE2 : public Nan::ObjectWrap {
 		bool	ignoreCase;
 		bool	multiline;
 		bool	sticky;
+		bool    safeToCutBeginning;
 		size_t	lastIndex;
 
 		bool DoExec(const StringPiece& input, StringPiece& match, size_t numberOfGroups = 1);
 		bool DoExec(const StringPiece& input, std::vector<StringPiece>& groups, bool autoResizeGroups = true);
+
+		size_t GetStartIndexHint() const;
 };
 
 

--- a/tests/test_exec.js
+++ b/tests/test_exec.js
@@ -169,5 +169,36 @@ unit.add(module, [
 		eval(t.TEST("re.lastIndex === 58"));
 
 		eval(t.TEST("result.input.toString('utf8', result.index) === 'Охотник Желает Знать Где Сидит Фазан'"));
-		eval(t.TEST("result.input.toString('utf8', re.lastIndex) === ' Сидит Фазан'"));	}
+		eval(t.TEST("result.input.toString('utf8', re.lastIndex) === ' Сидит Фазан'"));
+	},
+
+	// Sticky tests
+
+	function test_execSticky(t) {
+		"use strict";
+
+		var re = new RE2("\\s+", "y");
+
+		eval(t.TEST("re.exec('Hello world, how are you?') === null"));
+
+		re.lastIndex = 5;
+
+		var result = re.exec("Hello world, how are you?");
+
+		eval(t.TEST("t.unify(result, [' '])"));
+		eval(t.TEST("result.index === 5"));
+		eval(t.TEST("re.lastIndex === 6"));
+
+		var re2 = new RE2("\\s+", "gy");
+
+		eval(t.TEST("re2.exec('Hello world, how are you?') === null"));
+
+		re2.lastIndex = 5;
+
+		var result2 = re2.exec("Hello world, how are you?");
+
+		eval(t.TEST("t.unify(result2, [' '])"));
+		eval(t.TEST("result2.index === 5"));
+		eval(t.TEST("re2.lastIndex === 6"));
+	},
 ]);

--- a/tests/test_exec.js
+++ b/tests/test_exec.js
@@ -75,6 +75,18 @@ unit.add(module, [
 		eval(t.TEST("result[1] === 'aaa'"));
 		eval(t.TEST("result[2] === undefined"));
 	},
+	function test_execInvalid(t) {
+		"use strict";
+
+		var re = RE2('');
+
+		try {
+			re.exec({ toString() { throw "corner"; } });
+			t.test(false); // shouldn't be here
+		} catch(e) {
+			eval(t.TEST("e === 'corner'"));
+		}
+	},
 
 	// Unicode tests
 

--- a/tests/test_exec.js
+++ b/tests/test_exec.js
@@ -75,6 +75,19 @@ unit.add(module, [
 		eval(t.TEST("result[1] === 'aaa'"));
 		eval(t.TEST("result[2] === undefined"));
 	},
+	function test_execAnchoredToBeginning(t) {
+		"use strict";
+
+		var re = RE2('^hello', 'g');
+
+		var result = re.exec("hellohello");
+
+		eval(t.TEST("t.unify(result, ['hello'])"));
+		eval(t.TEST("result.index === 0"));
+		eval(t.TEST("re.lastIndex === 5"));
+
+		eval(t.TEST("re.exec('hellohello') === null"));
+	},
 	function test_execInvalid(t) {
 		"use strict";
 

--- a/tests/test_general.js
+++ b/tests/test_general.js
@@ -82,6 +82,13 @@ unit.add(module, [
 		} catch(e) {
 			eval(t.TEST("e instanceof TypeError"));
 		}
+
+		try {
+			var re = RE2({ toString() { throw "corner"; } });
+			t.test(false); // shouldn't be here
+		} catch(e) {
+			eval(t.TEST("e instanceof TypeError"));
+		}
 	},
 	function test_generalIn(t) {
 		"use strict";
@@ -203,6 +210,15 @@ unit.add(module, [
 
 		eval(t.TEST("b3.length === 1"));
 		eval(t.TEST("RE2.getUtf16Length(b3) === 2"));
+
+		try {
+			RE2.getUtf8Length({ toString() { throw "corner"; } });
+			t.test(false); // shouldn't be here
+		} catch(e) {
+			eval(t.TEST("e === 'corner'"));
+		}
+
+		eval(t.TEST("RE2.getUtf16Length({ toString() { throw 'corner'; } }) === -1"));
 	},
 	function test_sourceTranslation(t) {
 		"use strict";

--- a/tests/test_general.js
+++ b/tests/test_general.js
@@ -98,6 +98,7 @@ unit.add(module, [
 		eval(t.TEST("'global' in re"));
 		eval(t.TEST("'ignoreCase' in re"));
 		eval(t.TEST("'multiline' in re"));
+		eval(t.TEST("'sticky' in re"));
 		eval(t.TEST("'lastIndex' in re"));
 	},
 	function test_generalPresent(t) {
@@ -115,6 +116,7 @@ unit.add(module, [
 		eval(t.TEST("typeof re.global == 'boolean'"));
 		eval(t.TEST("typeof re.ignoreCase == 'boolean'"));
 		eval(t.TEST("typeof re.multiline == 'boolean'"));
+		eval(t.TEST("typeof re.sticky == 'boolean'"));
 		eval(t.TEST("typeof re.lastIndex == 'number'"));
 	},
 	function test_generalLastIndex(t) {
@@ -231,4 +233,5 @@ function compare(re1, re2, t) {
 	eval(t.TEST("re1.global === re2.global"));
 	eval(t.TEST("re1.ignoreCase === re2.ignoreCase"));
 	eval(t.TEST("re1.multiline  === re2.multiline"));
+	eval(t.TEST("re1.sticky     === re2.sticky"));
 }

--- a/tests/test_match.js
+++ b/tests/test_match.js
@@ -90,5 +90,36 @@ unit.add(module, [
 		eval(t.TEST("result[0].toString() === 'ГЛАВА 3.4.5.1'"));
 		eval(t.TEST("result[1].toString() === 'ГЛАВА 3.4.5.1'"));
 		eval(t.TEST("result[2].toString() === '.1'"));
-	}
+	},
+
+	// Sticky tests
+
+	function test_matchSticky(t) {
+		"use strict";
+
+		var re = new RE2("\\s+", "y");
+
+		eval(t.TEST("re.match('Hello world, how are you?') === null"));
+
+		re.lastIndex = 5;
+
+		var result = re.match("Hello world, how are you?");
+
+		eval(t.TEST("t.unify(result, [' '])"));
+		eval(t.TEST("result.index === 5"));
+		eval(t.TEST("re.lastIndex === 6"));
+
+		var re2 = new RE2("\\s+", "gy");
+
+		eval(t.TEST("re2.match('Hello world, how are you?') === null"));
+
+		re2.lastIndex = 5;
+		
+		eval(t.TEST("re2.match('Hello world, how are you?') === null"));
+
+		var re3 = new RE2(/[A-E]/giy);
+		var result3 = re3.match("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
+
+		eval(t.TEST("t.unify(result3, ['A', 'B', 'C', 'D', 'E'])"));
+	},
 ]);

--- a/tests/test_match.js
+++ b/tests/test_match.js
@@ -49,6 +49,18 @@ unit.add(module, [
 		eval(t.TEST("result[1] === 'aaa'"));
 		eval(t.TEST("result[2] === undefined"));
 	},
+	function test_matchInvalid(t) {
+		"use strict";
+
+		var re = RE2('');
+
+		try {
+			re.match({ toString() { throw "corner"; } });
+			t.test(false); // shouldn't be here
+		} catch(e) {
+			eval(t.TEST("e === 'corner'"));
+		}
+	},
 
 	// Unicode tests
 
@@ -114,7 +126,7 @@ unit.add(module, [
 		eval(t.TEST("re2.match('Hello world, how are you?') === null"));
 
 		re2.lastIndex = 5;
-		
+
 		eval(t.TEST("re2.match('Hello world, how are you?') === null"));
 
 		var re3 = new RE2(/[A-E]/giy);

--- a/tests/test_prototype.js
+++ b/tests/test_prototype.js
@@ -15,6 +15,7 @@ unit.add(module, [
 		eval(t.TEST("RE2.prototype.global === undefined"));
 		eval(t.TEST("RE2.prototype.ignoreCase === undefined"));
 		eval(t.TEST("RE2.prototype.multiline === undefined"));
+		eval(t.TEST("RE2.prototype.sticky === undefined"));
 		eval(t.TEST("RE2.prototype.lastIndex === undefined"));
 	}
 ]);

--- a/tests/test_replace.js
+++ b/tests/test_replace.js
@@ -160,5 +160,31 @@ unit.add(module, [
 		var result = re.replace("ИВАН и пЁтр", replacer);
 		eval(t.TEST("typeof result == 'string'"));
 		eval(t.TEST("result === 'Иван и Пётр'"));
-	}
+	},
+
+	// Sticky tests
+
+	function test_replaceSticky(t) {
+		"use strict";
+
+		var re = new RE2(/[A-E]/y);
+
+		eval(t.TEST("re.replace('ABCDEFABCDEF', '!') === '!BCDEFABCDEF'"));
+		eval(t.TEST("re.replace('ABCDEFABCDEF', '!') === 'A!CDEFABCDEF'"));
+		eval(t.TEST("re.replace('ABCDEFABCDEF', '!') === 'AB!DEFABCDEF'"));
+		eval(t.TEST("re.replace('ABCDEFABCDEF', '!') === 'ABC!EFABCDEF'"));
+		eval(t.TEST("re.replace('ABCDEFABCDEF', '!') === 'ABCD!FABCDEF'"));
+		eval(t.TEST("re.replace('ABCDEFABCDEF', '!') === 'ABCDEFABCDEF'"));
+		eval(t.TEST("re.replace('ABCDEFABCDEF', '!') === '!BCDEFABCDEF'"));
+
+		var re2 = new RE2(/[A-E]/gy);
+
+		eval(t.TEST("re2.replace('ABCDEFABCDEF', '!') === '!!!!!FABCDEF'"));
+		eval(t.TEST("re2.replace('FABCDEFABCDE', '!') === 'FABCDEFABCDE'"));
+
+		re2.lastIndex = 3;
+
+		eval(t.TEST("re2.replace('ABCDEFABCDEF', '!') === '!!!!!FABCDEF'"));
+		eval(t.TEST("re2.lastIndex === 0"));
+	},
 ]);

--- a/tests/test_replace.js
+++ b/tests/test_replace.js
@@ -86,6 +86,49 @@ unit.add(module, [
 			{text: "on:  2"}
 		]
 	},
+	function test_replaceInvalid(t) {
+		"use strict";
+
+		var re = RE2('');
+
+		try {
+			re.replace({ toString() { throw "corner1"; } }, '');
+			t.test(false); // shouldn't be here
+		} catch(e) {
+			eval(t.TEST("e === 'corner1'"));
+		}
+
+		try {
+			re.replace('', { toString() { throw "corner2"; } });
+			t.test(false); // shouldn't be here
+		} catch(e) {
+			eval(t.TEST("e === 'corner2'"));
+		}
+
+		var arg2Stringified = false;
+
+		try {
+			re.replace({ toString() { throw "corner1"; } }, { toString() { arg2Stringified = true; throw "corner2"; } });
+			t.test(false); // shouldn't be here
+		} catch(e) {
+			eval(t.TEST("e === 'corner1'"));
+			eval(t.TEST("!arg2Stringified"));
+		}
+
+		try {
+			re.replace('', () => { throw "corner2"; });
+			t.test(false); // shouldn't be here
+		} catch(e) {
+			eval(t.TEST("e === 'corner2'"));
+		}
+
+		try {
+			re.replace('', () => ({ toString() { throw "corner2"; } }));
+			t.test(false); // shouldn't be here
+		} catch(e) {
+			eval(t.TEST("e === 'corner2'"));
+		}
+	},
 
 	// Unicode tests
 

--- a/tests/test_search.js
+++ b/tests/test_search.js
@@ -70,5 +70,26 @@ unit.add(module, [
 		re = new RE2("z", "gm");
 		result = re.search(buf);
 		eval(t.TEST("result === -1"));
-	}
+	},
+	function test_searchSticky(t) {
+		"use strict";
+
+		var str = "Total is 42 units.";
+
+		var re = new RE2(/\d+/y);
+		var result = re.search(str);
+		eval(t.TEST("result === -1"));
+
+		re = new RE2("\\b[a-z]+\\b", "y");
+		result = re.search(str);
+		eval(t.TEST("result === -1"));
+
+		re = new RE2("\\b\\w+\\b", "y");
+		result = re.search(str);
+		eval(t.TEST("result === 0"));
+
+		re = new RE2("z", "gmy");
+		result = re.search(str);
+		eval(t.TEST("result === -1"));
+	},
 ]);

--- a/tests/test_search.js
+++ b/tests/test_search.js
@@ -29,6 +29,18 @@ unit.add(module, [
 		result = re.search(str);
 		eval(t.TEST("result === -1"));
 	},
+	function test_searchInvalid(t) {
+		"use strict";
+
+		var re = RE2('');
+
+		try {
+			re.search({ toString() { throw "corner"; } });
+			t.test(false); // shouldn't be here
+		} catch(e) {
+			eval(t.TEST("e === 'corner'"));
+		}
+	},
 	function test_searchUnicode(t) {
 		"use strict";
 

--- a/tests/test_split.js
+++ b/tests/test_split.js
@@ -20,6 +20,10 @@ unit.add(module, [
 		eval(t.TEST("t.unify(result, ['Oh', 'brave', 'new', 'world', 'that', 'has', 'such', 'people', 'in', 'it.'])"));
 
 		re = new RE2(",");
+		result = re.split("Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec");
+		eval(t.TEST("t.unify(result, ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'])"));
+
+		re = new RE2(",");
 		result = re.split(",Jan,Feb,Mar,Apr,May,Jun,,Jul,Aug,Sep,Oct,Nov,Dec,");
 		eval(t.TEST("t.unify(result, ['','Jan','Feb','Mar','Apr','May','Jun','','Jul','Aug','Sep','Oct','Nov','Dec',''])"));
 
@@ -36,6 +40,18 @@ unit.add(module, [
 		eval(t.TEST("t.unify(result, ['Hello ', '1', ' word. Sentence number ', '2', '.'])"));
 
 		eval(t.TEST("RE2(/[x-z]*/).split('asdfghjkl').reverse().join('') === 'lkjhgfdsa'"));
+	},
+	function test_splitInvalid(t) {
+		"use strict";
+
+		var re = RE2('');
+
+		try {
+			re.split({ toString() { throw "corner"; } });
+			t.test(false); // shouldn't be here
+		} catch(e) {
+			eval(t.TEST("e === 'corner'"));
+		}
 	},
 
 	// Unicode tests

--- a/tests/test_split.js
+++ b/tests/test_split.js
@@ -20,8 +20,8 @@ unit.add(module, [
 		eval(t.TEST("t.unify(result, ['Oh', 'brave', 'new', 'world', 'that', 'has', 'such', 'people', 'in', 'it.'])"));
 
 		re = new RE2(",");
-		result = re.split("Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec");
-		eval(t.TEST("t.unify(result, ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'])"));
+		result = re.split(",Jan,Feb,Mar,Apr,May,Jun,,Jul,Aug,Sep,Oct,Nov,Dec,");
+		eval(t.TEST("t.unify(result, ['','Jan','Feb','Mar','Apr','May','Jun','','Jul','Aug','Sep','Oct','Nov','Dec',''])"));
 
 		re = new RE2(/\s*;\s*/);
 		result = re.split("Harry Trump ;Fred Barney; Helen Rigby ; Bill Abel ;Chris Hand ");
@@ -92,7 +92,21 @@ unit.add(module, [
 		eval(t.TEST("t.unify(verifyBuffer(result, t), ['Привет ', '1', ' слово. Предложение номер ', '2', '.'])"));
 
 		eval(t.TEST("RE2(/[э-я]*/).split(new Buffer('фывапролд')).map(function(x) { return x.toString(); }).reverse().join('') === 'длорпавыф'"));
-	}
+	},
+
+	// Sticky tests
+
+	function test_splitSticky(t) {
+		"use strict";
+
+		var re = new RE2(/\s+/y);
+
+		var result = re.split("Oh brave new world that has such people in it.");
+		eval(t.TEST("t.unify(result, ['Oh brave new world that has such people in it.'])"));
+
+		var result2 = re.split(" Oh brave new world that has such people in it.");
+		eval(t.TEST("t.unify(result2, ['', 'Oh brave new world that has such people in it.'])"));
+	},
 ]);
 
 

--- a/tests/test_test.js
+++ b/tests/test_test.js
@@ -50,6 +50,18 @@ unit.add(module, [
 
 		eval(t.TEST("!re3.test(str)"));
 	},
+	function test_testInvalid(t) {
+		"use strict";
+
+		var re = RE2('');
+
+		try {
+			re.test({ toString() { throw "corner"; } });
+			t.test(false); // shouldn't be here
+		} catch(e) {
+			eval(t.TEST("e === 'corner'"));
+		}
+	},
 
 	// Unicode tests
 

--- a/tests/test_test.js
+++ b/tests/test_test.js
@@ -97,5 +97,29 @@ unit.add(module, [
 
 		eval(t.TEST("re.test(new Buffer('Это просто привет всем.'))"));
 		eval(t.TEST("!re.test(new Buffer('Это просто Привет всем.'))"));
-	}
+	},
+
+	// Sticky tests
+
+	function test_testSticky(t) {
+		"use strict";
+
+		var re = new RE2("\\s+", "y");
+
+		eval(t.TEST("!re.test('Hello world, how are you?')"));
+
+		re.lastIndex = 5;
+
+		eval(t.TEST("re.test('Hello world, how are you?')"));
+		eval(t.TEST("re.lastIndex === 6"));
+
+		var re2 = new RE2("\\s+", "gy");
+
+		eval(t.TEST("!re2.test('Hello world, how are you?')"));
+
+		re2.lastIndex = 5;
+
+		eval(t.TEST("re2.test('Hello world, how are you?')"));
+		eval(t.TEST("re2.lastIndex === 6"));
+	},
 ]);

--- a/tests/test_test.js
+++ b/tests/test_test.js
@@ -50,6 +50,14 @@ unit.add(module, [
 
 		eval(t.TEST("!re3.test(str)"));
 	},
+	function test_testAnchoredToBeginning(t) {
+		"use strict";
+
+		var re = RE2('^hello', 'g');
+
+		eval(t.TEST("re.test('hellohello')"));
+		eval(t.TEST("!re.test('hellohello')"));
+	},
 	function test_testInvalid(t) {
 		"use strict";
 

--- a/tests/test_toString.js
+++ b/tests/test_toString.js
@@ -11,6 +11,7 @@ unit.add(module, [
 	function test_toString(t) {
 		"use strict";
 
+		eval(t.TEST("RE2('').toString() === '/(?:)/'"));
 		eval(t.TEST("RE2('a').toString() === '/a/'"));
 		eval(t.TEST("RE2('b', 'i').toString() === '/b/i'"));
 		eval(t.TEST("RE2('c', 'g').toString() === '/c/g'"));
@@ -21,5 +22,6 @@ unit.add(module, [
 		eval(t.TEST("RE2('\\\\D{,2}', 'mig') + '' === '/\\\\D{,2}/igm'"));
 		eval(t.TEST("RE2('^a{2,}', 'mi') + '' === '/^a{2,}/im'"));
 		eval(t.TEST("RE2('^a{5}$', 'gim') + '' === '/^a{5}$/igm'"));
+		eval(t.TEST("RE2('\\\\u{1F603}/', 'iy') + '' === '/\\\\x{1F603}\\\\//iy'"));
 	}
 ]);


### PR DESCRIPTION
This PR :
- Fixes the combination of the `^` operator and `/g` (see also #29) ;
- Refactors some parts of many of the algorithms of the library ;
- Adds support for `/y` (see also #23) ;
- Makes the library more exception-friendly (in many cases, if some code called back by the library throws an exception, it'll be catchable by the caller, instead of crashing Node).