### PR TITLE
Add unicode property, add /u, deprecate constructing without /u

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,6 +5,7 @@
       "sources": [
         "lib/addon.cc",
         "lib/new.cc",
+        "lib/console.cc",
         "lib/exec.cc",
         "lib/test.cc",
         "lib/match.cc",

--- a/lib/accessors.cc
+++ b/lib/accessors.cc
@@ -35,6 +35,7 @@ NAN_GETTER(WrappedRE2::GetFlags) {
 	if (re2->multiline) {
 		flags += "m";
 	}
+	flags += "u";
 	if (re2->sticky) {
 		flags += "y";
 	}
@@ -72,6 +73,16 @@ NAN_GETTER(WrappedRE2::GetMultiline) {
 
 	WrappedRE2* re2 = Nan::ObjectWrap::Unwrap<WrappedRE2>(info.This());
 	info.GetReturnValue().Set(re2->multiline);
+}
+
+
+NAN_GETTER(WrappedRE2::GetUnicode) {
+	if (!WrappedRE2::HasInstance(info.This())) {
+		info.GetReturnValue().SetUndefined();
+		return;
+	}
+
+	info.GetReturnValue().Set(true);
 }
 
 

--- a/lib/addon.cc
+++ b/lib/addon.cc
@@ -61,6 +61,7 @@ void WrappedRE2::Initialize(Handle<Object> exports, Handle<Object> module) {
 	Nan::SetAccessor(proto, Nan::New("global").ToLocalChecked(),     GetGlobal);
 	Nan::SetAccessor(proto, Nan::New("ignoreCase").ToLocalChecked(), GetIgnoreCase);
 	Nan::SetAccessor(proto, Nan::New("multiline").ToLocalChecked(),  GetMultiline);
+	Nan::SetAccessor(proto, Nan::New("unicode").ToLocalChecked(),    GetUnicode);
 	Nan::SetAccessor(proto, Nan::New("sticky").ToLocalChecked(),     GetSticky);
 	Nan::SetAccessor(proto, Nan::New("lastIndex").ToLocalChecked(),  GetLastIndex, SetLastIndex);
 

--- a/lib/console.cc
+++ b/lib/console.cc
@@ -1,0 +1,56 @@
+#include "./util.h"
+
+#include <string>
+
+#include <sys/types.h>
+#include <unistd.h>
+
+
+using v8::Local;
+using v8::MaybeLocal;
+using v8::Object;
+using v8::String;
+using v8::Value;
+using std::string;
+
+
+template<typename R, typename P, typename L>
+inline MaybeLocal<R> bind(MaybeLocal<P> param, L lambda) {
+	if (param.IsEmpty()) return MaybeLocal<R>();
+
+	return lambda(param.ToLocalChecked());
+}
+
+
+void consoleCall(const Local<String>& methodName, Local<Value> text) {
+	Local<v8::Context> context = v8::Isolate::GetCurrent()->GetCurrentContext();
+
+	MaybeLocal<Object> maybeConsole = bind<Object>(
+		Nan::Get(context->Global(), Nan::New("console").ToLocalChecked()),
+		[context] (Local<Value> console) { return console->ToObject(context); });
+	if (maybeConsole.IsEmpty()) return;
+
+	Local<Object> console = maybeConsole.ToLocalChecked();
+
+	MaybeLocal<Object> maybeMethod = bind<Object>(
+		Nan::Get(console, methodName),
+		[context] (Local<Value> method) { return method->ToObject(context); });
+	if (maybeMethod.IsEmpty()) return;
+
+	Local<Object> method = maybeMethod.ToLocalChecked();
+	if (!method->IsFunction()) return;
+
+	Nan::Call(method.As<Function>(), console, 1, &text);
+}
+
+
+void printDeprecationWarning(const char* warning) {
+	string prefixedWarning;
+	prefixedWarning.resize(29 + sizeof(pid_t) * 3 + strlen(warning));
+	prefixedWarning.resize(snprintf(
+		&prefixedWarning[0], prefixedWarning.size(),
+		"(node:%d) DeprecationWarning: %s",
+		getpid(), warning));
+
+	consoleCall(Nan::New("error").ToLocalChecked(), Nan::New(prefixedWarning).ToLocalChecked());
+}

--- a/lib/to_string.cc
+++ b/lib/to_string.cc
@@ -23,15 +23,16 @@ NAN_METHOD(WrappedRE2::ToString) {
 	buffer += re2->regexp.pattern();
 	buffer += "/";
 
-	if (re2->ignoreCase) {
-		buffer += "i";
-	}
 	if (re2->global) {
 		buffer += "g";
+	}
+	if (re2->ignoreCase) {
+		buffer += "i";
 	}
 	if (re2->multiline) {
 		buffer += "m";
 	}
+	buffer += "u";
 	if (re2->sticky) {
 		buffer += "y";
 	}

--- a/lib/util.h
+++ b/lib/util.h
@@ -20,4 +20,8 @@ struct StrVal {
 };
 
 
+void consoleCall(const v8::Local<v8::String>& methodName, Local<v8::Value> text);
+void printDeprecationWarning(const char* warning);
+
+
 #endif

--- a/lib/wrapped_re2.h
+++ b/lib/wrapped_re2.h
@@ -33,6 +33,7 @@ class WrappedRE2 : public Nan::ObjectWrap {
 		static NAN_GETTER(GetGlobal);
 		static NAN_GETTER(GetIgnoreCase);
 		static NAN_GETTER(GetMultiline);
+		static NAN_GETTER(GetUnicode);
 		static NAN_GETTER(GetSticky);
 		static NAN_GETTER(GetLastIndex);
 		static NAN_SETTER(SetLastIndex);

--- a/tests/test_exec.js
+++ b/tests/test_exec.js
@@ -15,7 +15,7 @@ unit.add(module, [
 	function test_execBasic(t) {
 		"use strict";
 
-		var re = new RE2("quick\\s(brown).+?(jumps)", "ig");
+		var re = new RE2("quick\\s(brown).+?(jumps)", "igu");
 
 		eval(t.TEST("re.source === 'quick\\\\s(brown).+?(jumps)'"));
 		eval(t.TEST("re.ignoreCase"));
@@ -34,7 +34,7 @@ unit.add(module, [
 
 		var str = "abbcdefabh";
 
-		var re = new RE2("ab*", "g");
+		var re = new RE2("ab*", "gu");
 		var result = re.exec(str);
 
 		eval(t.TEST("!!result"));
@@ -56,7 +56,7 @@ unit.add(module, [
 	function test_execSimple(t) {
 		"use strict";
 
-		var re = new RE2("(hello \\S+)");
+		var re = new RE2("(hello \\S+)", "u");
 		var result = re.exec("This is a hello world!");
 
 		eval(t.TEST("result[1] === 'hello world!'"));
@@ -64,7 +64,7 @@ unit.add(module, [
 	function test_execFail(t) {
 		"use strict";
 
-		var re = new RE2("(a+)?(b+)?");
+		var re = new RE2("(a+)?(b+)?", "u");
 		var result = re.exec("aaabb");
 
 		eval(t.TEST("result[1] === 'aaa'"));
@@ -78,7 +78,7 @@ unit.add(module, [
 	function test_execAnchoredToBeginning(t) {
 		"use strict";
 
-		var re = RE2('^hello', 'g');
+		var re = RE2('^hello', 'gu');
 
 		var result = re.exec("hellohello");
 
@@ -91,7 +91,7 @@ unit.add(module, [
 	function test_execInvalid(t) {
 		"use strict";
 
-		var re = RE2('');
+		var re = RE2('', "u");
 
 		try {
 			re.exec({ toString() { throw "corner"; } });
@@ -103,7 +103,7 @@ unit.add(module, [
 	function test_execAnchor1(t) {
 		"use strict";
 
-		var re = new RE2("b|^a", "g");
+		var re = new RE2("b|^a", "gu");
 
 		var result = re.exec("aabc");
 		eval(t.TEST("!!result"));
@@ -121,7 +121,7 @@ unit.add(module, [
 	function test_execAnchor2(t) {
 		"use strict";
 
-		var re = new RE2("(?:^a)", "g");
+		var re = new RE2("(?:^a)", "gu");
 
 		var result = re.exec("aabc");
 		eval(t.TEST("!!result"));
@@ -137,7 +137,7 @@ unit.add(module, [
 	function test_execUnicode(t) {
 		"use strict";
 
-		var re = new RE2("охотник\\s(желает).+?(где)", "ig");
+		var re = new RE2("охотник\\s(желает).+?(где)", "igu");
 
 		eval(t.TEST("re.source === 'охотник\\\\s(желает).+?(где)'"));
 		eval(t.TEST("re.ignoreCase"));
@@ -159,7 +159,7 @@ unit.add(module, [
 
 		var str = "аббвгдеабё";
 
-		var re = new RE2("аб*", "g");
+		var re = new RE2("аб*", "gu");
 		var result = re.exec(str);
 
 		eval(t.TEST("!!result"));
@@ -181,7 +181,7 @@ unit.add(module, [
 	function test_execUnicodeSupplementary(t) {
 		"use strict";
 
-		var re = new RE2("\\u{1F603}", "g");
+		var re = new RE2("\\u{1F603}", "gu");
 
 		eval(t.TEST("re.source === '\\\\x{1F603}'"));
 		eval(t.TEST("!re.ignoreCase"));
@@ -195,7 +195,7 @@ unit.add(module, [
 		eval(t.TEST("result.input === '\\u{1F603}'"));
 		eval(t.TEST("re.lastIndex === 2"));
 
-		var re2 = new RE2(".", "g");
+		var re2 = new RE2(".", "gu");
 
 		eval(t.TEST("re2.source === '.'"));
 		eval(t.TEST("!re2.ignoreCase"));
@@ -209,7 +209,7 @@ unit.add(module, [
 		eval(t.TEST("result2.input === '\\u{1F603}'"));
 		eval(t.TEST("re2.lastIndex === 2"));
 
-		var re3 = new RE2("[\u{1F603}-\u{1F605}]", "g");
+		var re3 = new RE2("[\u{1F603}-\u{1F605}]", "gu");
 
 		eval(t.TEST("re3.source === '[\u{1F603}-\u{1F605}]'"));
 		eval(t.TEST("!re3.ignoreCase"));
@@ -229,7 +229,7 @@ unit.add(module, [
 	function test_execBuffer(t) {
 		"use strict";
 
-		var re  = new RE2("охотник\\s(желает).+?(где)", "ig");
+		var re  = new RE2("охотник\\s(желает).+?(где)", "igu");
 		var buf = new Buffer("Каждый Охотник Желает Знать Где Сидит Фазан");
 
 		var result = re.exec(buf);
@@ -257,7 +257,7 @@ unit.add(module, [
 	function test_execSticky(t) {
 		"use strict";
 
-		var re = new RE2("\\s+", "y");
+		var re = new RE2("\\s+", "yu");
 
 		eval(t.TEST("re.exec('Hello world, how are you?') === null"));
 
@@ -269,7 +269,7 @@ unit.add(module, [
 		eval(t.TEST("result.index === 5"));
 		eval(t.TEST("re.lastIndex === 6"));
 
-		var re2 = new RE2("\\s+", "gy");
+		var re2 = new RE2("\\s+", "gyu");
 
 		eval(t.TEST("re2.exec('Hello world, how are you?') === null"));
 

--- a/tests/test_general.js
+++ b/tests/test_general.js
@@ -18,23 +18,23 @@ unit.add(module, [
 	function test_generalInst(t) {
 		"use strict";
 
-		var re1 = new RE2("\\d+");
+		var re1 = new RE2("\\d+", "u");
 
 		eval(t.TEST("!!re1"));
 		eval(t.TEST("re1 instanceof RE2"));
 
-		var re2 = RE2("\\d+");
+		var re2 = RE2("\\d+", "u");
 
 		eval(t.TEST("!!re2"));
 		eval(t.TEST("re2 instanceof RE2"));
 		compare(re1, re2, t);
 
-		re1 = new RE2("\\d+", "m");
+		re1 = new RE2("\\d+", "mu");
 
 		eval(t.TEST("!!re1"));
 		eval(t.TEST("re1 instanceof RE2"));
 
-		re2 = RE2("\\d+", "m");
+		re2 = RE2("\\d+", "mu");
 
 		eval(t.TEST("!!re2"));
 		eval(t.TEST("re2 instanceof RE2"));
@@ -93,7 +93,7 @@ unit.add(module, [
 	function test_generalIn(t) {
 		"use strict";
 
-		var re = new RE2("\\d+");
+		var re = new RE2("\\d+", "u");
 
 		eval(t.TEST("'exec' in re"));
 		eval(t.TEST("'test' in re"));
@@ -112,7 +112,7 @@ unit.add(module, [
 	function test_generalPresent(t) {
 		"use strict";
 
-		var re = new RE2("\\d+");
+		var re = new RE2("\\d+", "u");
 
 		eval(t.TEST("typeof re.exec == 'function'"));
 		eval(t.TEST("typeof re.test == 'function'"));
@@ -131,7 +131,7 @@ unit.add(module, [
 	function test_generalLastIndex(t) {
 		"use strict";
 
-		var re = new RE2("\\d+");
+		var re = new RE2("\\d+", "u");
 
 		eval(t.TEST("re.lastIndex === 0"));
 
@@ -146,8 +146,8 @@ unit.add(module, [
 	function test_generalRegExp(t) {
 		"use strict";
 
-		var re1 = new RegExp("\\d+");
-		var re2 = new RE2("\\d+");
+		var re1 = new RegExp("\\d+", "u");
+		var re2 = new RE2("\\d+", "u");
 
 		compare(re1, re2, t);
 
@@ -155,8 +155,8 @@ unit.add(module, [
 
 		compare(re1, re2, t);
 
-		re1 = new RegExp("a", "ig");
-		re2 = new RE2("a", "ig");
+		re1 = new RegExp("a", "igu");
+		re2 = new RE2("a", "igu");
 
 		compare(re1, re2, t);
 
@@ -164,8 +164,8 @@ unit.add(module, [
 
 		compare(re1, re2, t);
 
-		re1 = /\s/gm;
-		re2 = new RE2("\\s", "mg");
+		re1 = /\s/gmu;
+		re2 = new RE2("\\s", "mgu");
 
 		compare(re1, re2, t);
 
@@ -173,11 +173,11 @@ unit.add(module, [
 
 		compare(re1, re2, t);
 
-		re2 = new RE2(/\s/gm);
+		re2 = new RE2(/\s/gmu);
 
-		compare(/\s/gm, re2, t);
+		compare(/\s/gmu, re2, t);
 
-		re1 = new RE2("b", "gm");
+		re1 = new RE2("b", "gmu");
 		re2 = new RE2(re1);
 
 		compare(re1, re2, t);
@@ -228,56 +228,56 @@ unit.add(module, [
 	function test_sourceTranslation(t) {
 		"use strict";
 
-		var re = new RE2("a\\cM\\u34\\u1234\\u10abcdz");
+		var re = new RE2("a\\cM\\u34\\u1234\\u10abcdz", "u");
 		eval(t.TEST("re.source === 'a\\\\x0D\\\\x{34}\\\\x{1234}\\\\x{10ab}cdz'"));
 
-		var re = new RE2("a\\cM\\u34\\u1234\\u{10abcd}z");
+		var re = new RE2("a\\cM\\u34\\u1234\\u{10abcd}z", "u");
 		eval(t.TEST("re.source === 'a\\\\x0D\\\\x{34}\\\\x{1234}\\\\x{10abcd}z'"));
 
-		var re = new RE2("");
+		var re = new RE2("", "u");
 		eval(t.TEST("re.source === '(?:)'"));
 
-		var re = new RE2("foo/bar");
+		var re = new RE2("foo/bar", "u");
 		eval(t.TEST("re.source === 'foo\\\\/bar'"));
 
-		var re = new RE2("foo\\/bar");
+		var re = new RE2("foo\\/bar", "u");
 		eval(t.TEST("re.source === 'foo\\\\/bar'"));
 	},
 	function test_flags(t) {
 		"use strict";
 
-		var re = new RE2("a");
-		eval(t.TEST("re.flags === ''"));
+		var re = new RE2("a", "u");
+		eval(t.TEST("re.flags === 'u'"));
 
-		re = new RE2("a", "i");
-		eval(t.TEST("re.flags === 'i'"));
+		re = new RE2("a", "iu");
+		eval(t.TEST("re.flags === 'iu'"));
 
-		re = new RE2("a", "m");
-		eval(t.TEST("re.flags === 'm'"));
+		re = new RE2("a", "mu");
+		eval(t.TEST("re.flags === 'mu'"));
 
-		re = new RE2("a", "g");
-		eval(t.TEST("re.flags === 'g'"));
+		re = new RE2("a", "gu");
+		eval(t.TEST("re.flags === 'gu'"));
 
-		re = new RE2("a", "y");
-		eval(t.TEST("re.flags === 'y'"));
+		re = new RE2("a", "yu");
+		eval(t.TEST("re.flags === 'uy'"));
 
-		re = new RE2("a", "yi");
-		eval(t.TEST("re.flags === 'iy'"));
+		re = new RE2("a", "yiu");
+		eval(t.TEST("re.flags === 'iuy'"));
 
-		re = new RE2("a", "yig");
-		eval(t.TEST("re.flags === 'giy'"));
+		re = new RE2("a", "yigu");
+		eval(t.TEST("re.flags === 'giuy'"));
 
-		re = new RE2("a", "mi");
-		eval(t.TEST("re.flags === 'im'"));
+		re = new RE2("a", "miu");
+		eval(t.TEST("re.flags === 'imu'"));
 
-		re = new RE2("a", "yg");
-		eval(t.TEST("re.flags === 'gy'"));
+		re = new RE2("a", "ygu");
+		eval(t.TEST("re.flags === 'guy'"));
 
-		re = new RE2("a", "my");
-		eval(t.TEST("re.flags === 'my'"));
+		re = new RE2("a", "myu");
+		eval(t.TEST("re.flags === 'muy'"));
 
-		re = new RE2("a", "migy");
-		eval(t.TEST("re.flags === 'gimy'"));
+		re = new RE2("a", "migyu");
+		eval(t.TEST("re.flags === 'gimuy'"));
 	}
 ]);
 
@@ -290,5 +290,6 @@ function compare(re1, re2, t) {
 	eval(t.TEST("re1.global === re2.global"));
 	eval(t.TEST("re1.ignoreCase === re2.ignoreCase"));
 	eval(t.TEST("re1.multiline  === re2.multiline"));
+	eval(t.TEST("re1.unicode    === re2.unicode"));
 	eval(t.TEST("re1.sticky     === re2.sticky"));
 }

--- a/tests/test_invalid.js
+++ b/tests/test_invalid.js
@@ -17,7 +17,7 @@ unit.add(module, [
 		// Backreferences
 		threw = false;
 		try {
-			new RE2(/(a)\1/);
+			new RE2(/(a)\1/u);
 		} catch (e) {
 			threw = true;
 			eval(t.TEST("e instanceof SyntaxError"));
@@ -29,7 +29,7 @@ unit.add(module, [
 		// Positive
 		threw = false;
 		try {
-			new RE2(/a(?=b)/);
+			new RE2(/a(?=b)/u);
 		} catch (e) {
 			threw = true;
 			eval(t.TEST("e instanceof SyntaxError"));
@@ -39,7 +39,7 @@ unit.add(module, [
 		// Negative
 		threw = false;
 		try {
-			new RE2(/a(?!b)/);
+			new RE2(/a(?!b)/u);
 		} catch (e) {
 			threw = true;
 			eval(t.TEST("e instanceof SyntaxError"));

--- a/tests/test_match.js
+++ b/tests/test_match.js
@@ -17,7 +17,7 @@ unit.add(module, [
 
 		var str = "For more information, see Chapter 3.4.5.1";
 
-		var re = new RE2(/(chapter \d+(\.\d)*)/i);
+		var re = new RE2(/(chapter \d+(\.\d)*)/iu);
 		var result = re.match(str);
 
 		eval(t.TEST("result.input === str"));
@@ -30,7 +30,7 @@ unit.add(module, [
 	function test_matchGlobal(t) {
 		"use strict";
 
-		var re = new RE2(/[A-E]/gi);
+		var re = new RE2(/[A-E]/giu);
 		var result = re.match("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
 
 		eval(t.TEST("t.unify(result, ['A', 'B', 'C', 'D', 'E', 'a', 'b', 'c', 'd', 'e'])"));
@@ -38,7 +38,7 @@ unit.add(module, [
 	function test_matchFail(t) {
 		"use strict";
 
-		var re = new RE2("(a+)?(b+)?");
+		var re = new RE2("(a+)?(b+)?", "u");
 		var result = re.match("aaabb");
 
 		eval(t.TEST("result[1] === 'aaa'"));
@@ -52,7 +52,7 @@ unit.add(module, [
 	function test_matchInvalid(t) {
 		"use strict";
 
-		var re = RE2('');
+		var re = RE2('', "u");
 
 		try {
 			re.match({ toString() { throw "corner"; } });
@@ -69,7 +69,7 @@ unit.add(module, [
 
 		var str = "Это ГЛАВА 3.4.5.1";
 
-		var re = new RE2(/(глава \d+(\.\d)*)/i);
+		var re = new RE2(/(глава \d+(\.\d)*)/iu);
 		var result = re.match(str);
 
 		eval(t.TEST("result.input === str"));
@@ -87,7 +87,7 @@ unit.add(module, [
 
 		var buf = new Buffer("Это ГЛАВА 3.4.5.1");
 
-		var re = new RE2(/(глава \d+(\.\d)*)/i);
+		var re = new RE2(/(глава \d+(\.\d)*)/iu);
 		var result = re.match(buf);
 
 		eval(t.TEST("result.input instanceof Buffer"));
@@ -109,7 +109,7 @@ unit.add(module, [
 	function test_matchSticky(t) {
 		"use strict";
 
-		var re = new RE2("\\s+", "y");
+		var re = new RE2("\\s+", "yu");
 
 		eval(t.TEST("re.match('Hello world, how are you?') === null"));
 
@@ -121,7 +121,7 @@ unit.add(module, [
 		eval(t.TEST("result.index === 5"));
 		eval(t.TEST("re.lastIndex === 6"));
 
-		var re2 = new RE2("\\s+", "gy");
+		var re2 = new RE2("\\s+", "gyu");
 
 		eval(t.TEST("re2.match('Hello world, how are you?') === null"));
 
@@ -129,7 +129,7 @@ unit.add(module, [
 
 		eval(t.TEST("re2.match('Hello world, how are you?') === null"));
 
-		var re3 = new RE2(/[A-E]/giy);
+		var re3 = new RE2(/[A-E]/giyu);
 		var result3 = re3.match("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
 
 		eval(t.TEST("t.unify(result3, ['A', 'B', 'C', 'D', 'E'])"));

--- a/tests/test_prototype.js
+++ b/tests/test_prototype.js
@@ -16,6 +16,7 @@ unit.add(module, [
 		eval(t.TEST("RE2.prototype.global === undefined"));
 		eval(t.TEST("RE2.prototype.ignoreCase === undefined"));
 		eval(t.TEST("RE2.prototype.multiline  === undefined"));
+		eval(t.TEST("RE2.prototype.unicode    === undefined"));
 		eval(t.TEST("RE2.prototype.sticky     === undefined"));
 		eval(t.TEST("RE2.prototype.lastIndex  === undefined"));
 	}

--- a/tests/test_replace.js
+++ b/tests/test_replace.js
@@ -15,15 +15,15 @@ unit.add(module, [
 	function test_replaceString(t) {
 		"use strict";
 
-		var re = new RE2(/apples/gi);
+		var re = new RE2(/apples/giu);
 		var result = re.replace("Apples are round, and apples are juicy.", "oranges");
 		eval(t.TEST("result === 'oranges are round, and oranges are juicy.'"));
 
-		re = new RE2(/xmas/i);
+		re = new RE2(/xmas/iu);
 		result = re.replace("Twas the night before Xmas...", "Christmas");
 		eval(t.TEST("result === 'Twas the night before Christmas...'"));
 
-		re = new RE2(/(\w+)\s(\w+)/);
+		re = new RE2(/(\w+)\s(\w+)/u);
 		result = re.replace("John Smith", "$2, $1");
 		eval(t.TEST("result === 'Smith, John'"));
 	},
@@ -35,7 +35,7 @@ unit.add(module, [
 			return [p1, p2, p3].join(' - ');
 		}
 
-		var re = new RE2(/([^\d]*)(\d*)([^\w]*)/);
+		var re = new RE2(/([^\d]*)(\d*)([^\w]*)/u);
 		var result = re.replace("abc12345#$*%", replacer);
 		eval(t.TEST("result === 'abc - 12345 - #$*%'"));
 	},
@@ -46,7 +46,7 @@ unit.add(module, [
 			return '-' + match.toLowerCase();
 		}
 
-		var re = new RE2(/[A-Z]/g);
+		var re = new RE2(/[A-Z]/gu);
 		var result = re.replace("borderTop", upperToHyphenLower);
 		eval(t.TEST("result === 'border-top'"));
 	},
@@ -57,7 +57,7 @@ unit.add(module, [
 			return ((p1 - 32) * 5/9) + 'C';
 		}
 
-		var re = new RE2(/(\d+(?:\.\d*)?)F\b/g);
+		var re = new RE2(/(\d+(?:\.\d*)?)F\b/gu);
 
 		eval(t.TEST("re.replace('32F', convert) === '0C'"));
 		eval(t.TEST("re.replace('41F', convert) === '5C'"));
@@ -75,7 +75,7 @@ unit.add(module, [
 		test: function test_replaceFunLoop(t) {
 			"use strict";
 
-			RE2(/(x_*)|(-)/g).replace("x-x_", function(match, p1, p2) {
+			RE2(/(x_*)|(-)/gu).replace("x-x_", function(match, p1, p2) {
 				if (p1) { t.info("on:  " + p1.length); }
 				if (p2) { t.info("off: 1"); }
 			});
@@ -89,7 +89,7 @@ unit.add(module, [
 	function test_replaceInvalid(t) {
 		"use strict";
 
-		var re = RE2('');
+		var re = RE2('', "u");
 
 		try {
 			re.replace({ toString() { throw "corner1"; } }, '');
@@ -135,19 +135,19 @@ unit.add(module, [
 	function test_replaceStrUnicode(t) {
 		"use strict";
 
-		var re = new RE2(/яблоки/gi);
+		var re = new RE2(/яблоки/giu);
 		var result = re.replace("Яблоки красны, яблоки сочны.", "апельсины");
 		eval(t.TEST("result === 'апельсины красны, апельсины сочны.'"));
 
-		re = new RE2(/иван/i);
+		re = new RE2(/иван/iu);
 		result = re.replace("Могуч Иван Иванов...", "Сидор");
 		eval(t.TEST("result === 'Могуч Сидор Иванов...'"));
 
-		re = new RE2(/иван/ig);
+		re = new RE2(/иван/igu);
 		result = re.replace("Могуч Иван Иванов...", "Сидор");
 		eval(t.TEST("result === 'Могуч Сидор Сидоров...'"));
 
-		re = new RE2(/([а-яё]+)\s+([а-яё]+)/i);
+		re = new RE2(/([а-яё]+)\s+([а-яё]+)/iu);
 		result = re.replace("Пётр Петров", "$2, $1");
 		eval(t.TEST("result === 'Петров, Пётр'"));
 	},
@@ -162,7 +162,7 @@ unit.add(module, [
 			return match.charAt(0).toUpperCase() + match.substr(1).toLowerCase();
 		}
 
-		var re = new RE2(/(?:иван|пётр|сидор)/ig);
+		var re = new RE2(/(?:иван|пётр|сидор)/igu);
 		var result = re.replace("ИВАН и пЁтр", replacer);
 		eval(t.TEST("result === 'Иван и Пётр'"));
 	},
@@ -172,7 +172,7 @@ unit.add(module, [
 	function test_replaceStrBuffer(t) {
 		"use strict";
 
-		var re = new RE2(/яблоки/gi);
+		var re = new RE2(/яблоки/giu);
 		var result = re.replace(new Buffer("Яблоки красны, яблоки сочны."), "апельсины");
 		eval(t.TEST("result instanceof Buffer"));
 		eval(t.TEST("result.toString() === 'апельсины красны, апельсины сочны.'"));
@@ -199,7 +199,7 @@ unit.add(module, [
 		}
 		replacer.useBuffers = true;
 
-		var re = new RE2(/(?:иван|пётр|сидор)/ig);
+		var re = new RE2(/(?:иван|пётр|сидор)/igu);
 		var result = re.replace("ИВАН и пЁтр", replacer);
 		eval(t.TEST("typeof result == 'string'"));
 		eval(t.TEST("result === 'Иван и Пётр'"));
@@ -210,7 +210,7 @@ unit.add(module, [
 	function test_replaceSticky(t) {
 		"use strict";
 
-		var re = new RE2(/[A-E]/y);
+		var re = new RE2(/[A-E]/yu);
 
 		eval(t.TEST("re.replace('ABCDEFABCDEF', '!') === '!BCDEFABCDEF'"));
 		eval(t.TEST("re.replace('ABCDEFABCDEF', '!') === 'A!CDEFABCDEF'"));
@@ -220,7 +220,7 @@ unit.add(module, [
 		eval(t.TEST("re.replace('ABCDEFABCDEF', '!') === 'ABCDEFABCDEF'"));
 		eval(t.TEST("re.replace('ABCDEFABCDEF', '!') === '!BCDEFABCDEF'"));
 
-		var re2 = new RE2(/[A-E]/gy);
+		var re2 = new RE2(/[A-E]/gyu);
 
 		eval(t.TEST("re2.replace('ABCDEFABCDEF', '!') === '!!!!!FABCDEF'"));
 		eval(t.TEST("re2.replace('FABCDEFABCDE', '!') === 'FABCDEFABCDE'"));

--- a/tests/test_search.js
+++ b/tests/test_search.js
@@ -13,26 +13,26 @@ unit.add(module, [
 
 		var str = "Total is 42 units.";
 
-		var re = new RE2(/\d+/i);
+		var re = new RE2(/\d+/iu);
 		var result = re.search(str);
 		eval(t.TEST("result === 9"));
 
-		re = new RE2("\\b[a-z]+\\b");
+		re = new RE2("\\b[a-z]+\\b", "u");
 		result = re.search(str);
 		eval(t.TEST("result === 6"));
 
-		re = new RE2("\\b\\w+\\b");
+		re = new RE2("\\b\\w+\\b", "u");
 		result = re.search(str);
 		eval(t.TEST("result === 0"));
 
-		re = new RE2("z", "gm");
+		re = new RE2("z", "gmu");
 		result = re.search(str);
 		eval(t.TEST("result === -1"));
 	},
 	function test_searchInvalid(t) {
 		"use strict";
 
-		var re = RE2('');
+		var re = RE2('', "u");
 
 		try {
 			re.search({ toString() { throw "corner"; } });
@@ -46,19 +46,19 @@ unit.add(module, [
 
 		var str = "Всего 42 штуки.";
 
-		var re = new RE2(/\d+/i);
+		var re = new RE2(/\d+/iu);
 		var result = re.search(str);
 		eval(t.TEST("result === 6"));
 
-		re = new RE2("\\s[а-я]+");
+		re = new RE2("\\s[а-я]+", "u");
 		result = re.search(str);
 		eval(t.TEST("result === 8"));
 
-		re = new RE2("[а-яА-Я]+");
+		re = new RE2("[а-яА-Я]+", "u");
 		result = re.search(str);
 		eval(t.TEST("result === 0"));
 
-		re = new RE2("z", "gm");
+		re = new RE2("z", "gmu");
 		result = re.search(str);
 		eval(t.TEST("result === -1"));
 	},
@@ -67,19 +67,19 @@ unit.add(module, [
 
 		var buf = new Buffer("Всего 42 штуки.");
 
-		var re = new RE2(/\d+/i);
+		var re = new RE2(/\d+/iu);
 		var result = re.search(buf);
 		eval(t.TEST("result === 11"));
 
-		re = new RE2("\\s[а-я]+");
+		re = new RE2("\\s[а-я]+", "u");
 		result = re.search(buf);
 		eval(t.TEST("result === 13"));
 
-		re = new RE2("[а-яА-Я]+");
+		re = new RE2("[а-яА-Я]+", "u");
 		result = re.search(buf);
 		eval(t.TEST("result === 0"));
 
-		re = new RE2("z", "gm");
+		re = new RE2("z", "gmu");
 		result = re.search(buf);
 		eval(t.TEST("result === -1"));
 	},
@@ -88,19 +88,19 @@ unit.add(module, [
 
 		var str = "Total is 42 units.";
 
-		var re = new RE2(/\d+/y);
+		var re = new RE2(/\d+/yu);
 		var result = re.search(str);
 		eval(t.TEST("result === -1"));
 
-		re = new RE2("\\b[a-z]+\\b", "y");
+		re = new RE2("\\b[a-z]+\\b", "yu");
 		result = re.search(str);
 		eval(t.TEST("result === -1"));
 
-		re = new RE2("\\b\\w+\\b", "y");
+		re = new RE2("\\b\\w+\\b", "yu");
 		result = re.search(str);
 		eval(t.TEST("result === 0"));
 
-		re = new RE2("z", "gmy");
+		re = new RE2("z", "gmyu");
 		result = re.search(str);
 		eval(t.TEST("result === -1"));
 	}

--- a/tests/test_split.js
+++ b/tests/test_split.js
@@ -15,36 +15,36 @@ unit.add(module, [
 	function test_split(t) {
 		"use strict";
 
-		var re = new RE2(/\s+/);
+		var re = new RE2(/\s+/u);
 		var result = re.split("Oh brave new world that has such people in it.");
 		eval(t.TEST("t.unify(result, ['Oh', 'brave', 'new', 'world', 'that', 'has', 'such', 'people', 'in', 'it.'])"));
 
-		re = new RE2(",");
+		re = new RE2(",", "u");
 		result = re.split("Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec");
 		eval(t.TEST("t.unify(result, ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'])"));
 
-		re = new RE2(",");
+		re = new RE2(",", "u");
 		result = re.split(",Jan,Feb,Mar,Apr,May,Jun,,Jul,Aug,Sep,Oct,Nov,Dec,");
 		eval(t.TEST("t.unify(result, ['','Jan','Feb','Mar','Apr','May','Jun','','Jul','Aug','Sep','Oct','Nov','Dec',''])"));
 
-		re = new RE2(/\s*;\s*/);
+		re = new RE2(/\s*;\s*/u);
 		result = re.split("Harry Trump ;Fred Barney; Helen Rigby ; Bill Abel ;Chris Hand ");
 		eval(t.TEST("t.unify(result, ['Harry Trump', 'Fred Barney', 'Helen Rigby', 'Bill Abel', 'Chris Hand '])"));
 
-		re = new RE2(/\s+/);
+		re = new RE2(/\s+/u);
 		result = re.split("Hello World. How are you doing?", 3);
 		eval(t.TEST("t.unify(result, ['Hello', 'World.', 'How'])"));
 
-		re = new RE2(/(\d)/);
+		re = new RE2(/(\d)/u);
 		result = re.split("Hello 1 word. Sentence number 2.");
 		eval(t.TEST("t.unify(result, ['Hello ', '1', ' word. Sentence number ', '2', '.'])"));
 
-		eval(t.TEST("RE2(/[x-z]*/).split('asdfghjkl').reverse().join('') === 'lkjhgfdsa'"));
+		eval(t.TEST("RE2(/[x-z]*/u).split('asdfghjkl').reverse().join('') === 'lkjhgfdsa'"));
 	},
 	function test_splitInvalid(t) {
 		"use strict";
 
-		var re = RE2('');
+		var re = RE2('', "u");
 
 		try {
 			re.split({ toString() { throw "corner"; } });
@@ -57,7 +57,7 @@ unit.add(module, [
 	function test_cornerCases(t) {
 		"use strict";
 
-		var re = new RE2(/1/);
+		var re = new RE2(/1/u);
 		var result = re.split("23456");
 		eval(t.TEST("t.unify(result, ['23456'])"));
 	},
@@ -67,27 +67,27 @@ unit.add(module, [
 	function test_splitUnicode(t) {
 		"use strict";
 
-		var re = new RE2(/\s+/);
+		var re = new RE2(/\s+/u);
 		var result = re.split("Она не понимает, что этим убивает меня.");
 		eval(t.TEST("t.unify(result, ['Она', 'не', 'понимает,', 'что', 'этим', 'убивает', 'меня.'])"));
 
-		re = new RE2(",");
+		re = new RE2(",", "u");
 		result = re.split("Пн,Вт,Ср,Чт,Пт,Сб,Вс");
 		eval(t.TEST("t.unify(result, ['Пн','Вт','Ср','Чт','Пт','Сб','Вс'])"));
 
-		re = new RE2(/\s*;\s*/);
+		re = new RE2(/\s*;\s*/u);
 		result = re.split("Ваня Иванов ;Петро Петренко; Саша Машин ; Маша Сашина");
 		eval(t.TEST("t.unify(result, ['Ваня Иванов', 'Петро Петренко', 'Саша Машин', 'Маша Сашина'])"));
 
-		re = new RE2(/\s+/);
+		re = new RE2(/\s+/u);
 		result = re.split("Привет мир. Как дела?", 3);
 		eval(t.TEST("t.unify(result, ['Привет', 'мир.', 'Как'])"));
 
-		re = new RE2(/(\d)/);
+		re = new RE2(/(\d)/u);
 		result = re.split("Привет 1 слово. Предложение номер 2.");
 		eval(t.TEST("t.unify(result, ['Привет ', '1', ' слово. Предложение номер ', '2', '.'])"));
 
-		eval(t.TEST("RE2(/[э-я]*/).split('фывапролд').reverse().join('') === 'длорпавыф'"));
+		eval(t.TEST("RE2(/[э-я]*/u).split('фывапролд').reverse().join('') === 'длорпавыф'"));
 	},
 
 	// Buffer tests
@@ -95,27 +95,27 @@ unit.add(module, [
 	function test_splitBuffer(t) {
 		"use strict";
 
-		var re = new RE2(/\s+/);
+		var re = new RE2(/\s+/u);
 		var result = re.split(new Buffer("Она не понимает, что этим убивает меня."));
 		eval(t.TEST("t.unify(verifyBuffer(result, t), ['Она', 'не', 'понимает,', 'что', 'этим', 'убивает', 'меня.'])"));
 
-		re = new RE2(",");
+		re = new RE2(",", "u");
 		result = re.split(new Buffer("Пн,Вт,Ср,Чт,Пт,Сб,Вс"));
 		eval(t.TEST("t.unify(verifyBuffer(result, t), ['Пн','Вт','Ср','Чт','Пт','Сб','Вс'])"));
 
-		re = new RE2(/\s*;\s*/);
+		re = new RE2(/\s*;\s*/u);
 		result = re.split(new Buffer("Ваня Иванов ;Петро Петренко; Саша Машин ; Маша Сашина"));
 		eval(t.TEST("t.unify(verifyBuffer(result, t), ['Ваня Иванов', 'Петро Петренко', 'Саша Машин', 'Маша Сашина'])"));
 
-		re = new RE2(/\s+/);
+		re = new RE2(/\s+/u);
 		result = re.split(new Buffer("Привет мир. Как дела?"), 3);
 		eval(t.TEST("t.unify(verifyBuffer(result, t), ['Привет', 'мир.', 'Как'])"));
 
-		re = new RE2(/(\d)/);
+		re = new RE2(/(\d)/u);
 		result = re.split(new Buffer("Привет 1 слово. Предложение номер 2."));
 		eval(t.TEST("t.unify(verifyBuffer(result, t), ['Привет ', '1', ' слово. Предложение номер ', '2', '.'])"));
 
-		eval(t.TEST("RE2(/[э-я]*/).split(new Buffer('фывапролд')).map(function(x) { return x.toString(); }).reverse().join('') === 'длорпавыф'"));
+		eval(t.TEST("RE2(/[э-я]*/u).split(new Buffer('фывапролд')).map(function(x) { return x.toString(); }).reverse().join('') === 'длорпавыф'"));
 	},
 
 	// Sticky tests
@@ -123,7 +123,7 @@ unit.add(module, [
 	function test_splitSticky(t) {
 		"use strict";
 
-		var re = new RE2(/\s+/y); // sticky is ignored
+		var re = new RE2(/\s+/yu); // sticky is ignored
 
 		var result = re.split("Oh brave new world that has such people in it.");
 		eval(t.TEST("t.unify(result, ['Oh', 'brave', 'new', 'world', 'that', 'has', 'such', 'people', 'in', 'it.'])"));

--- a/tests/test_symbols.js
+++ b/tests/test_symbols.js
@@ -15,7 +15,7 @@ unit.add(module, [
 
 		var str = "For more information, see Chapter 3.4.5.1";
 
-		var re = new RE2(/(chapter \d+(\.\d)*)/i);
+		var re = new RE2(/(chapter \d+(\.\d)*)/iu);
 		var result = str.match(re);
 
 		eval(t.TEST("result.input === str"));
@@ -32,19 +32,19 @@ unit.add(module, [
 
 		var str = "Total is 42 units.";
 
-		var re = new RE2(/\d+/i);
+		var re = new RE2(/\d+/iu);
 		var result = str.search(re);
 		eval(t.TEST("result === 9"));
 
-		re = new RE2("\\b[a-z]+\\b");
+		re = new RE2("\\b[a-z]+\\b", "u");
 		result = str.search(re);
 		eval(t.TEST("result === 6"));
 
-		re = new RE2("\\b\\w+\\b");
+		re = new RE2("\\b\\w+\\b", "u");
 		result = str.search(re);
 		eval(t.TEST("result === 0"));
 
-		re = new RE2("z", "gm");
+		re = new RE2("z", "gmu");
 		result = str.search(re);
 		eval(t.TEST("result === -1"));
 	},
@@ -53,15 +53,15 @@ unit.add(module, [
 
 		if (typeof Symbol == 'undefined' || !Symbol.replace) return;
 
-		var re = new RE2(/apples/gi);
+		var re = new RE2(/apples/giu);
 		var result = "Apples are round, and apples are juicy.".replace(re, "oranges");
 		eval(t.TEST("result === 'oranges are round, and oranges are juicy.'"));
 
-		re = new RE2(/xmas/i);
+		re = new RE2(/xmas/iu);
 		result = "Twas the night before Xmas...".replace(re, "Christmas");
 		eval(t.TEST("result === 'Twas the night before Christmas...'"));
 
-		re = new RE2(/(\w+)\s(\w+)/);
+		re = new RE2(/(\w+)\s(\w+)/u);
 		result = "John Smith".replace(re, "$2, $1");
 		eval(t.TEST("result === 'Smith, John'"));
 	},
@@ -70,26 +70,26 @@ unit.add(module, [
 
 		if (typeof Symbol == 'undefined' || !Symbol.split) return;
 
-		var re = new RE2(/\s+/);
+		var re = new RE2(/\s+/u);
 		var result = "Oh brave new world that has such people in it.".split(re);
 		eval(t.TEST("t.unify(result, ['Oh', 'brave', 'new', 'world', 'that', 'has', 'such', 'people', 'in', 'it.'])"));
 
-		re = new RE2(",");
+		re = new RE2(",", "u");
 		result = "Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec".split(re);
 		eval(t.TEST("t.unify(result, ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'])"));
 
-		re = new RE2(/\s*;\s*/);
+		re = new RE2(/\s*;\s*/u);
 		result = "Harry Trump ;Fred Barney; Helen Rigby ; Bill Abel ;Chris Hand ".split(re);
 		eval(t.TEST("t.unify(result, ['Harry Trump', 'Fred Barney', 'Helen Rigby', 'Bill Abel', 'Chris Hand '])"));
 
-		re = new RE2(/\s+/);
+		re = new RE2(/\s+/u);
 		result = "Hello World. How are you doing?".split(re, 3);
 		eval(t.TEST("t.unify(result, ['Hello', 'World.', 'How'])"));
 
-		re = new RE2(/(\d)/);
+		re = new RE2(/(\d)/u);
 		result = "Hello 1 word. Sentence number 2.".split(re);
 		eval(t.TEST("t.unify(result, ['Hello ', '1', ' word. Sentence number ', '2', '.'])"));
 
-		eval(t.TEST("'asdfghjkl'.split(RE2(/[x-z]*/)).reverse().join('') === 'lkjhgfdsa'"));
+		eval(t.TEST("'asdfghjkl'.split(RE2(/[x-z]*/u)).reverse().join('') === 'lkjhgfdsa'"));
 	}
 ]);

--- a/tests/test_test.js
+++ b/tests/test_test.js
@@ -15,7 +15,7 @@ unit.add(module, [
 	function test_testFromExec(t) {
 		"use strict";
 
-		var re = new RE2("quick\\s(brown).+?(jumps)", "i");
+		var re = new RE2("quick\\s(brown).+?(jumps)", "iu");
 
 		eval(t.TEST("re.test('The Quick Brown Fox Jumps Over The Lazy Dog')"));
 		eval(t.TEST("re.test('tHE qUICK bROWN fOX jUMPS oVER tHE lAZY dOG')"));
@@ -23,12 +23,12 @@ unit.add(module, [
 		eval(t.TEST("re.test('THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG')"));
 		eval(t.TEST("!re.test('THE KWIK BROWN FOX JUMPS OVER THE LAZY DOG')"));
 
-		re = new RE2("ab*", "g");
+		re = new RE2("ab*", "gu");
 
 		eval(t.TEST("re.test('abbcdefabh')"));
 		eval(t.TEST("!re.test('qwerty')"));
 
-		re = new RE2("(hello \\S+)");
+		re = new RE2("(hello \\S+)", "u");
 
 		eval(t.TEST("re.test('This is a hello world!')"));
 		eval(t.TEST("!re.test('This is a Hello world!')"));
@@ -38,7 +38,7 @@ unit.add(module, [
 
 		var str = "abbcdefabh";
 
-		var re = new RE2("ab*", "g");
+		var re = new RE2("ab*", "gu");
 		var result = re.test(str);
 
 		eval(t.TEST("result"));
@@ -58,22 +58,22 @@ unit.add(module, [
 
 		var str = "abbcdefabh";
 
-		var re1 = new RE2("ab*", "g");
+		var re1 = new RE2("ab*", "gu");
 
 		eval(t.TEST("re1.test(str)"));
 
-		var re2 = new RE2("ab*");
+		var re2 = new RE2("ab*", "u");
 
 		eval(t.TEST("re2.test(str)"));
 
-		var re3 = new RE2("abc");
+		var re3 = new RE2("abc", "u");
 
 		eval(t.TEST("!re3.test(str)"));
 	},
 	function test_testAnchoredToBeginning(t) {
 		"use strict";
 
-		var re = RE2('^hello', 'g');
+		var re = RE2('^hello', 'gu');
 
 		eval(t.TEST("re.test('hellohello')"));
 		eval(t.TEST("!re.test('hellohello')"));
@@ -81,7 +81,7 @@ unit.add(module, [
 	function test_testInvalid(t) {
 		"use strict";
 
-		var re = RE2('');
+		var re = RE2('', "u");
 
 		try {
 			re.test({ toString() { throw "corner"; } });
@@ -93,7 +93,7 @@ unit.add(module, [
 	function test_testAnchor1(t) {
 		"use strict";
 
-		var re = new RE2("b|^a", "g");
+		var re = new RE2("b|^a", "gu");
 
 		var result = re.test("aabc");
 		eval(t.TEST("result"));
@@ -109,7 +109,7 @@ unit.add(module, [
 	function test_testAnchor2(t) {
 		"use strict";
 
-		var re = new RE2("(?:^a)", "g");
+		var re = new RE2("(?:^a)", "gu");
 
 		var result = re.test("aabc");
 		eval(t.TEST("result"));
@@ -124,7 +124,7 @@ unit.add(module, [
 	function test_testUnicode(t) {
 		"use strict";
 
-		var re = new RE2("охотник\\s(желает).+?(где)", "i");
+		var re = new RE2("охотник\\s(желает).+?(где)", "iu");
 
 		eval(t.TEST("re.test('Каждый Охотник Желает Знать Где Сидит Фазан')"));
 		eval(t.TEST("re.test('кАЖДЫЙ оХОТНИК жЕЛАЕТ зНАТЬ гДЕ сИДИТ фАЗАН')"));
@@ -132,12 +132,12 @@ unit.add(module, [
 		eval(t.TEST("re.test('КАЖДЫЙ ОХОТНИК ЖЕЛАЕТ ЗНАТЬ ГДЕ СИДИТ ФАЗАН')"));
 		eval(t.TEST("!re.test('Кажный Стрелок Хочет Найти Иде Прячется Птица')"));
 
-		re = new RE2("аб*", "g");
+		re = new RE2("аб*", "gu");
 
 		eval(t.TEST("re.test('аббвгдеабё')"));
 		eval(t.TEST("!re.test('йцукен')"));
 
-		re = new RE2("(привет \\S+)");
+		re = new RE2("(привет \\S+)", "u");
 
 		eval(t.TEST("re.test('Это просто привет всем.')"));
 		eval(t.TEST("!re.test('Это просто Привет всем.')"));
@@ -147,7 +147,7 @@ unit.add(module, [
 
 		var str = "аббвгдеабё";
 
-		var re = new RE2("аб*", "g");
+		var re = new RE2("аб*", "gu");
 		var result = re.test(str);
 
 		eval(t.TEST("result"));
@@ -168,7 +168,7 @@ unit.add(module, [
 	function test_testBuffer(t) {
 		"use strict";
 
-		var re = new RE2("охотник\\s(желает).+?(где)", "i");
+		var re = new RE2("охотник\\s(желает).+?(где)", "iu");
 
 		eval(t.TEST("re.test(new Buffer('Каждый Охотник Желает Знать Где Сидит Фазан'))"));
 		eval(t.TEST("re.test(new Buffer('кАЖДЫЙ оХОТНИК жЕЛАЕТ зНАТЬ гДЕ сИДИТ фАЗАН'))"));
@@ -176,12 +176,12 @@ unit.add(module, [
 		eval(t.TEST("re.test(new Buffer('КАЖДЫЙ ОХОТНИК ЖЕЛАЕТ ЗНАТЬ ГДЕ СИДИТ ФАЗАН'))"));
 		eval(t.TEST("!re.test(new Buffer('Кажный Стрелок Хочет Найти Иде Прячется Птица'))"));
 
-		re = new RE2("аб*", "g");
+		re = new RE2("аб*", "gu");
 
 		eval(t.TEST("re.test(new Buffer('аббвгдеабё'))"));
 		eval(t.TEST("!re.test(new Buffer('йцукен'))"));
 
-		re = new RE2("(привет \\S+)");
+		re = new RE2("(привет \\S+)", "u");
 
 		eval(t.TEST("re.test(new Buffer('Это просто привет всем.'))"));
 		eval(t.TEST("!re.test(new Buffer('Это просто Привет всем.'))"));
@@ -192,7 +192,7 @@ unit.add(module, [
 	function test_testSticky(t) {
 		"use strict";
 
-		var re = new RE2("\\s+", "y");
+		var re = new RE2("\\s+", "yu");
 
 		eval(t.TEST("!re.test('Hello world, how are you?')"));
 
@@ -201,7 +201,7 @@ unit.add(module, [
 		eval(t.TEST("re.test('Hello world, how are you?')"));
 		eval(t.TEST("re.lastIndex === 6"));
 
-		var re2 = new RE2("\\s+", "gy");
+		var re2 = new RE2("\\s+", "gyu");
 
 		eval(t.TEST("!re2.test('Hello world, how are you?')"));
 

--- a/tests/test_toString.js
+++ b/tests/test_toString.js
@@ -11,17 +11,17 @@ unit.add(module, [
 	function test_toString(t) {
 		"use strict";
 
-		eval(t.TEST("RE2('').toString() === '/(?:)/'"));
-		eval(t.TEST("RE2('a').toString() === '/a/'"));
-		eval(t.TEST("RE2('b', 'i').toString() === '/b/i'"));
-		eval(t.TEST("RE2('c', 'g').toString() === '/c/g'"));
-		eval(t.TEST("RE2('d', 'm').toString() === '/d/m'"));
-		eval(t.TEST("RE2('\\\\d+', 'gi') + '' === '/\\\\d+/ig'"));
-		eval(t.TEST("RE2('\\\\s*', 'gm') + '' === '/\\\\s*/gm'"));
-		eval(t.TEST("RE2('\\\\S{1,3}', 'ig') + '' === '/\\\\S{1,3}/ig'"));
-		eval(t.TEST("RE2('\\\\D{,2}', 'mig') + '' === '/\\\\D{,2}/igm'"));
-		eval(t.TEST("RE2('^a{2,}', 'mi') + '' === '/^a{2,}/im'"));
-		eval(t.TEST("RE2('^a{5}$', 'gim') + '' === '/^a{5}$/igm'"));
-		eval(t.TEST("RE2('\\\\u{1F603}/', 'iy') + '' === '/\\\\x{1F603}\\\\//iy'"));
+		eval(t.TEST("RE2('', 'u').toString() === '/(?:)/u'"));
+		eval(t.TEST("RE2('a', 'u').toString() === '/a/u'"));
+		eval(t.TEST("RE2('b', 'iu').toString() === '/b/iu'"));
+		eval(t.TEST("RE2('c', 'gu').toString() === '/c/gu'"));
+		eval(t.TEST("RE2('d', 'mu').toString() === '/d/mu'"));
+		eval(t.TEST("RE2('\\\\d+', 'giu') + '' === '/\\\\d+/giu'"));
+		eval(t.TEST("RE2('\\\\s*', 'gmu') + '' === '/\\\\s*/gmu'"));
+		eval(t.TEST("RE2('\\\\S{1,3}', 'igu') + '' === '/\\\\S{1,3}/giu'"));
+		eval(t.TEST("RE2('\\\\D{,2}', 'migu') + '' === '/\\\\D{,2}/gimu'"));
+		eval(t.TEST("RE2('^a{2,}', 'miu') + '' === '/^a{2,}/imu'"));
+		eval(t.TEST("RE2('^a{5}$', 'gimu') + '' === '/^a{5}$/gimu'"));
+		eval(t.TEST("RE2('\\\\u{1F603}/', 'iyu') + '' === '/\\\\x{1F603}\\\\//iuy'"));
 	}
 ]);


### PR DESCRIPTION
Implements my 1.7.*/1.8+ proposal for #21 :
- Adds a `.unicode` property, returning `undefined` for the prototype and always `true` for actual instances ;
- Adds the `u` character to the `.flags` property and the `.toString()` return value ; updates the tests accordingly ;
- On the first construction of a `RE2` object without the `u` flag, prints a deprecation warning using `console.error(…);`, like Node does for the first unhandled rejected `Promise` ; updates the tests not to trigger the warning.

Also :
- Reorders the flags returned by `.toString()` for consistency with `.flags` and the ES2015 spec ; updates the tests accordingly.