### PR TITLE
fix StrVar cast operator StringPiece

### DIFF
--- a/lib/util.h
+++ b/lib/util.h
@@ -15,8 +15,7 @@ struct StrVal {
 	StrVal() : data(NULL), size(0), length(0), isBuffer(false) {}
 	StrVal(const v8::Local<v8::Value>& arg);
 
-	operator StringPiece () { return StringPiece(data, size); }
-	operator const StringPiece () const { return StringPiece(data, size); }
+	operator StringPiece () const { return StringPiece(data, size); }
 };
 
 


### PR DESCRIPTION
../lib/replace.cc:149:24: error: no viable conversion from 'const StrVal' to 're2::StringPiece'
        const StringPiece str(replacee);

Using
gyp info using node-gyp@3.1.0
gyp info using node@10.3.0 | darwin | x64

% clang++ -v                                                                                                                                   6s ~/src/node-re2 master
Apple LLVM version 9.0.0 (clang-900.0.39.2)
Target: x86_64-apple-darwin17.5.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
