### PR TITLE
update typescript types to conform to typescript docs for `module.exports`-style exports

### DIFF
--- a/re2.d.ts
+++ b/re2.d.ts
@@ -1,1 +1,5 @@
-export class RE2 extends RegExp {}
+declare module 're2' {
+  class RE2 extends RegExp {}
+  export = RE2;
+}
+


### PR DESCRIPTION
see discussion on https://github.com/uhop/node-re2/pull/53