### PR TITLE
Fix result lengths with undefined groups

### DIFF
--- a/lib/exec.cc
+++ b/lib/exec.cc
@@ -83,6 +83,10 @@ NAN_METHOD(WrappedRE2::Exec)
 			{
 				Nan::Set(result, i, Nan::CopyBuffer(item.data(), item.size()).ToLocalChecked());
 			}
+			else
+			{
+				Nan::Set(result, i, Nan::Undefined());
+			}
 		}
 		Nan::Set(result, Nan::New("index").ToLocalChecked(), Nan::New<v8::Integer>(indexOffset + static_cast<int>(groups[0].data() - str.data)));
 	}
@@ -94,6 +98,10 @@ NAN_METHOD(WrappedRE2::Exec)
 			if (item.data() != NULL)
 			{
 				Nan::Set(result, i, Nan::New(item.data(), item.size()).ToLocalChecked());
+			}
+			else
+			{
+				Nan::Set(result, i, Nan::Undefined());
 			}
 		}
 		Nan::Set(result, Nan::New("index").ToLocalChecked(), Nan::New<v8::Integer>(indexOffset + static_cast<int>(getUtf16Length(str.data + lastIndex, groups[0].data()))));

--- a/tests/test_exec.js
+++ b/tests/test_exec.js
@@ -74,6 +74,7 @@ unit.add(module, [
 
 		eval(t.TEST("result[1] === 'aaa'"));
 		eval(t.TEST("result[2] === undefined"));
+		eval(t.TEST("result.length === 3"));
 	},
 	function test_execAnchoredToBeginning(t) {
 		"use strict";


### PR DESCRIPTION
We upgraded to the latest `re2` versions and it was returning sparse arrays.

This creates extremely confusing behavior. This patch ensures the blanks are filled in with `undefined` values, creating a consistent `.length` of the array.