### PR TITLE
allow overriding download url with RE2_DOWNLOAD_MIRROR

### DIFF
--- a/scripts/install-from-cache.js
+++ b/scripts/install-from-cache.js
@@ -53,10 +53,11 @@ const getAssetUrlPrefix = () => {
       process.env.npm_package_github ||
       process.env.npm_package_repository ||
       (process.env.npm_package_repository_type === 'git' && process.env.npm_package_repository_url),
-    result = getRepo(url);
+    result = getRepo(url),
+    host = process.env.RE2_DOWNLOAD_MIRROR || 'https://github.com';
   return (
     result &&
-    `https://github.com/${result[1]}/${result[2]}/releases/download/${process.env.npm_package_version}/${prefix}${platform}-${process.arch}-${process.versions.modules}${suffix}`
+    `${host}/${result[1]}/${result[2]}/releases/download/${process.env.npm_package_version}/${prefix}${platform}-${process.arch}-${process.versions.modules}${suffix}`
   );
 };
 


### PR DESCRIPTION
In our CI the re2 download failed for a while last night, which is a phenomenon we observe on a fairly regular basis with packages that download assets in their post install step from public urls. We prevent this from failing our CI by mirroring downloads within our CI environment. To do this we override download URLs for a number of packages which support this using environment variables:

```
export GECKODRIVER_CDNURL="..."
export CHROMEDRIVER_CDNURL="..."
export CYPRESS_DOWNLOAD_MIRROR="..."
```

These URLs are static and point to a prefix where the different packages will request the assets they seek to download, and we don't experience the same random failures we do when using public urls.

It would be great if node-re2 supported this as well, so I've added a check for the `RE2_DOWNLOAD_MIRROR` environment variable, and when it's defined it will override the `https://github.com` part of the download URL.