### PR TITLE
Refs #83 - Expose max_mem and never_capture RE2 options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ node-re2 makes vulnerable regular expression patterns safe by evaluating them in
 
 * [`new RE2(pattern[, flags])`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
 
+or optionally with [RE2 specific options](https://github.com/google/re2/blob/master/re2/re2.h#L594):
+
+* `new RE2(pattern[, flags, options])`
+
 Supported properties:
 
 * [`re2.lastIndex`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex)
@@ -61,6 +65,12 @@ Supported methods:
 * [`re2.exec(str)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec)
 * [`re2.test(str)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test)
 * [`re2.toString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/toString)
+
+Supported RE2 options:
+
+* [`max_mem`](https://github.com/google/re2/blob/master/re2/re2.h#L618)
+* [`never_capture`](https://github.com/google/re2/blob/master/re2/re2.h#L606)
+
 
 Starting with 1.6.0 following well-known symbol-based methods are supported (see [Symbols](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)):
 
@@ -237,6 +247,11 @@ re = new RE2("a(b*)", "i");
 result = re.exec("aBbC");
 console.log(result[0]); // "aBb"
 console.log(result[1]); // "Bb"
+
+// with max_mem option
+var re = new RE2("[0-9]+", undefined, {max_mem: 2 << 10});
+var result = re.exec("1234");
+console.log(result[0]); // "1234"
 
 // from regular expression object
 var regexp = new RegExp("a(b*)", "i");

--- a/tests/test_options.js
+++ b/tests/test_options.js
@@ -1,0 +1,66 @@
+"use strict";
+
+
+var unit = require("heya-unit");
+var RE2  = require("../re2");
+
+
+// tests
+
+unit.add(module, [
+	function test_noMemoryLimit(t) {
+		"use strict";
+
+		var re1 = new RE2("[0-9]+".repeat(1000));
+		eval(t.TEST("!!re1"));
+		eval(t.TEST("re1 instanceof RE2"));
+
+		var re2 = new RE2("[0-9]+".repeat(1000), undefined, {});
+		eval(t.TEST("!!re2"));
+		eval(t.TEST("re2 instanceof RE2"));
+	},
+	function test_memoryLimit(t) {
+		"use strict";
+
+		var re1 = new RE2("[0-9]+".repeat(100), undefined,
+					{max_mem: 2 << 10});
+		eval(t.TEST("!!re1"));
+		eval(t.TEST("re1 instanceof RE2"));
+
+		try {
+			var re2 = new RE2("[0-9]+".repeat(1000), undefined,
+					{max_mem: 2 << 10});
+			t.test(false); // shouldn't be here
+		} catch(e) {
+			eval(t.TEST("e instanceof SyntaxError"));
+			eval(t.TEST("e.message.startsWith('pattern too large')"));
+		}
+	},
+	function test_memoryLimitCapturing(t) {
+		"use strict";
+
+		var re1 = new RE2("(a)".repeat(50), undefined,
+					{max_mem: 2 << 10, never_capture: true});
+		eval(t.TEST("!!re1"));
+		eval(t.TEST("re1 instanceof RE2"));
+
+		try {
+			var re2 = new RE2("(a)".repeat(50), undefined,
+						{max_mem: 2 << 10,
+						never_capture: false});
+			t.test(false); // shouldn't be here
+		} catch(e) {
+			eval(t.TEST("e instanceof SyntaxError"));
+			eval(t.TEST("e.message.startsWith('pattern too large')"));
+		}
+
+		try {
+			var re3 = new RE2("(a)".repeat(50), undefined,
+						{max_mem: 2 << 10});
+			t.test(false); // shouldn't be here
+		} catch(e) {
+			eval(t.TEST("e instanceof SyntaxError"));
+			eval(t.TEST("e.message.startsWith('pattern too large')"));
+		}
+	}
+]);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -17,5 +17,6 @@ require("./test_symbols");
 require("./test_prototype");
 require("./test_new");
 require("./test_groups");
+require("./test_options");
 
 unit.run();


### PR DESCRIPTION
I've had a go at implementing the functionality I asked for with #83. While it does work and compile without warnings, I would especially recommend checking the code I've added to new.cc which reads the options. I'm not sure if I did that the best way, perhaps we can avoid some of the `ToLocalChecked()` etc calls?