### PR TITLE
Fixing post install scripts issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "install-artifact-from-github": "^1.2.0",
     "nan": "^2.14.2",
-    "node-gyp": "^7.0.0"
+    "node-gyp": "^7"
   },
   "devDependencies": {
     "heya-unit": "^0.3.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "install-artifact-from-github": "^1.2.0",
     "nan": "^2.14.2",
-    "node-gyp": "^8.0.0"
+    "node-gyp": "^7.0.0"
   },
   "devDependencies": {
     "heya-unit": "^0.3.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "test": "node tests/tests.js",
     "save-to-github": "save-to-github-cache --artifact build/Release/re2.node",
-    "install": "install-from-cache --artifact build/Release/re2.node --host-var RE2_DOWNLOAD_MIRROR || npm run rebuild",
+    "postinstall": "install-from-cache --artifact build/Release/re2.node --host-var RE2_DOWNLOAD_MIRROR || npm run rebuild",
     "verify-build": "node scripts/verify-build.js",
     "rebuild": "node-gyp rebuild"
   },


### PR DESCRIPTION
This is a fix for issue #92

Amending the post install lifecycle script to use `postinstall` instead of `install` as yarn does not support that.

Also downgraded `node-gyp` requirement to v7 for better compatibility on Windows.  