### PR TITLE
fix UTF-16 to UTF-8 index translation

### DIFF
--- a/lib/exec.cc
+++ b/lib/exec.cc
@@ -50,7 +50,9 @@ NAN_METHOD(WrappedRE2::Exec)
 			}
 			for (size_t n = re2->lastIndex; n; --n)
 			{
-				lastIndex += getUtf8CharSize(str.data[lastIndex]);
+				size_t s = getUtf8CharSize(str.data[lastIndex]);
+				lastIndex += s;
+				if (s == 4 && n >= 2) --n;
 			}
 		}
 	}


### PR DESCRIPTION
This addresses incorrect index translation affecting strings containing characters from Unicode Supplemental Planes (U+10000 - U+10FFFF). These characters use 2 code units in UTF-16 and counted as 2 "characters" in V8, such that `'🤡'.length === 2`. On the other hand in UTF-8 they are encoded using just one 4-byte unit. This caused the code to skip one extra character on each occurrence. For example  `'🤡abc'[2] === 'a'` but when translated the index would point to `b`