### PR TITLE
fix UTF-16 to UTF-8 index translation

### DIFF
--- a/lib/exec.cc
+++ b/lib/exec.cc
@@ -50,7 +50,9 @@ NAN_METHOD(WrappedRE2::Exec)
 			}
 			for (size_t n = re2->lastIndex; n; --n)
 			{
-				lastIndex += getUtf8CharSize(str.data[lastIndex]);
+				size_t s = getUtf8CharSize(str.data[lastIndex]);
+				lastIndex += s;
+				if (s == 4 && n >= 2) --n;
 			}
 		}
 	}

--- a/tests/test_exec.js
+++ b/tests/test_exec.js
@@ -284,6 +284,22 @@ unit.add(module, [
 		eval(t.TEST("re2.lastIndex === 6"));
   },
 
+	function test_execSupplemental(t) {
+		"use strict";
+
+		var re = new RE2("\\w+", "g");
+		var testString = "🤡🤡🤡 Hello clown world!";
+
+		var result = re.exec(testString);
+		eval(t.TEST("t.unify(result, ['Hello'])"));
+		
+		result = re.exec(testString);
+		eval(t.TEST("t.unify(result, ['clown'])"));
+
+		result = re.exec(testString);
+		eval(t.TEST("t.unify(result, ['world'])"));
+	},
+
   // Multiline test
 
   function test_execMultiline(t) {


### PR DESCRIPTION
This addresses incorrect index translation affecting strings containing characters from Unicode Supplemental Planes (U+10000 - U+10FFFF). These characters use 2 code units in UTF-16 and counted as 2 "characters" in V8, such that `'🤡'.length === 2`. On the other hand in UTF-8 they are encoded using just one 4-byte unit. This caused the code to skip one extra character on each occurrence. For example  `'🤡abc'[2] === 'a'` but when translated the index would point to `b`

i don't say that `getUtf8Length` and `getUtf16Length` functions work incorrectly by themselves, i say the specific code targeted by this commit (doing index translation) uses their results without regard for underlying semantics. Built-in regex has no such problem. In your examples this code has no chance to fail because `lastIndex == 0`, try matching with g flag:

```
> re2 = new RE2(/\d/g)

> re2.exec('🤡123')
[ '1', index: 2, input: '🤡123', groups: undefined ]
> re2.exec('🤡123')
[ '3', index: 3, input: '🤡123', groups: undefined ]
```
where's 2?

built-in regex works fine:
```
> let re = /\d/g

> re.exec('🤡123')
[ '1', index: 2, input: '🤡123', groups: undefined ]
> re.exec('🤡123')
[ '2', index: 3, input: '🤡123', groups: undefined ]
> re.exec('🤡123')
[ '3', index: 4, input: '🤡123', groups: undefined ]
```

In the supplied test case second exec would incorrectly match 'own' before fix, instead of 'clown'