### PR TITLE
Fix: infinite loop in matchAll() with empty matches

### DIFF
--- a/re2.js
+++ b/re2.js
@@ -29,6 +29,7 @@ if (typeof Symbol != 'undefined') {
       for (;;) {
         const result = re.exec(str);
         if (!result) break;
+        if (result[0] === '') re.lastIndex++;
         yield result;
       }
     });

--- a/tests/test_matchAll.js
+++ b/tests/test_matchAll.js
@@ -77,5 +77,19 @@ unit.add(module, [
       eval(t.TEST('match[0] === expected[i]'));
       ++i;
     }
+  },
+
+  function test_matchAll_empty_match(t) {
+    'use strict';
+
+    const str = 'foo';
+    // Matches empty strings, but should not cause an infinite loop
+    const re = new RE2('(?:)', 'g');
+    const result = Array.from(str.matchAll(re));
+
+    eval(t.TEST('result.length === str.length + 1'));
+    for (let i = 0; i < result.length; i++) {
+      eval(t.TEST(`result[${i}][0] === ''`));
+    }
   }
 ]);


### PR DESCRIPTION
The library's matchAll() method would enter an infinite loop when used with a regular expression that matches empty strings, such as /(?:)/g. This commit fixes the issue by manually incrementing the lastIndex property when an empty match is found.

Additionally, a new test case has been added to the test suite to verify that matchAll() works correctly with empty matches.