### PR TITLE
Fix build on NixOS

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -46,6 +46,7 @@
         "vendor/abseil-cpp/absl/base/internal/thread_identity.cc",
         "vendor/abseil-cpp/absl/base/internal/throw_delegate.cc",
         "vendor/abseil-cpp/absl/base/internal/unscaledcycleclock.cc",
+        "vendor/abseil-cpp/absl/debugging/internal/demangle.cc",
         "vendor/abseil-cpp/absl/container/internal/raw_hash_set.cc",
         "vendor/abseil-cpp/absl/debugging/internal/address_is_readable.cc",
         "vendor/abseil-cpp/absl/debugging/internal/elf_mem_image.cc",


### PR DESCRIPTION
After some testing, this file is required as well for the resulting binary to function on NixOS.

Otherwise, this error occurs:
<img width="1423" alt="image" src="https://github.com/uhop/node-re2/assets/18512463/a7b103de-9388-4e15-b42d-1786d74fba85">
