### PR TITLE
Do UTF-16 / UTF-8 conversion in JS for matchAll and replace, fixes #194

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ Two functions to calculate string sizes between
 
 * `RE2.getUtf8Length(str)` &mdash; calculates a buffer size in bytes to encode a UTF-16 string as
   a UTF-8 buffer.
-* `RE2.getUtf16Length(buf)` &mdash; calculates a string size in characters to encode a UTF-8 buffer as
-  a UTF-16 string.
+* `RE2.getUtf16Length(buf, [start, end])` &mdash; calculates a string size in characters to encode a UTF-8 buffer as
+  a UTF-16 string. Optionally, use start and end indices to only calculate the length of a slice.
 
 JavaScript supports UCS-2 strings with 16-bit characters, while node.js 0.11 supports full UTF-16 as
 a default string.

--- a/re2.js
+++ b/re2.js
@@ -2,6 +2,12 @@
 
 const RE2 = require('./build/Release/re2.node');
 
+const bufferReplace = RE2.prototype.replace;
+RE2.prototype.replace = function (str, repl) {
+  const convert = makeFormatConverter(str);
+  return bufferReplace.call(this, convert.buf, convert.toInternalReplacer(repl));
+}
+
 if (typeof Symbol != 'undefined') {
   Symbol.match &&
     (RE2.prototype[Symbol.match] = function (str) {
@@ -24,15 +30,132 @@ if (typeof Symbol != 'undefined') {
       if (!this.global) {
         throw TypeError('String.prototype.matchAll called with a non-global RE2 argument');
       }
+      const convert = makeFormatConverter(str);
       const re = new RE2(this);
-      re.lastIndex = this.lastIndex;
+      re.lastIndex = convert.toInternalIndex(this.lastIndex);
       for (;;) {
-        const result = re.exec(str);
+        const result = re.exec(convert.buf);
         if (!result) break;
         if (result[0] === '') ++re.lastIndex;
-        yield result;
+        yield convert.toExternalMatch(result);
       }
     });
+}
+
+function makeFormatConverter(str) {
+  if (str instanceof Buffer) {
+    return {
+      buf: str,
+      toInternalIndex(extIdx) { return extIdx; },
+      toInternalReplacer(repl) { return repl; },
+      toExternalIndex(intIdx) { return intIdx; },
+      toExternalMatch(match) { return match; },
+    };
+  }
+
+  const buf = Buffer.from(str, 'utf-8');
+
+  function toInternalIndex(extIdx) {
+    return RE2.getUtf8Length(str.slice(0, extIdx));
+  }
+
+  function toInternalReplacer(repl) {
+    if (typeof repl !== 'function') {
+      return repl instanceof Buffer ? repl : Buffer.from(repl, 'utf-8');
+    }
+    if (repl.useBuffers === true) {
+      return repl;
+    }
+
+    const wrapped = (...args) => {
+      const offsetPos = args.findIndex(x => typeof x === 'number');
+      for (let i = 0; i < offsetPos; i++) {
+        if (args[i]) args[i] = args[i].toString('utf-8');
+      }
+      args[offsetPos] = toExternalIndex(args[args.length - 3]);
+      args[offsetPos + 1] = str;
+
+      const groups = args[offsetPos + 2];
+      if (groups) {
+        for (const name of Object.keys(groups)) {
+          if (groups[name]) groups[name] = groups[name].toString('utf-8');
+        }
+      }
+
+      return repl(...args);
+    };
+    wrapped.useBuffers = true;
+    return wrapped;
+  }
+
+  let lastIntIdx = 0;
+  let lastExtIdx = 0;
+  function toExternalIndex(intIdx) {
+    if (intIdx < lastIntIdx) {
+      lastIntIdx = 0;
+      lastExtIdx = 0;
+    }
+    if (intIdx !== lastIntIdx) {
+      lastExtIdx += RE2.getUtf16Length(buf, lastIntIdx, intIdx);
+      lastIntIdx = intIdx;
+    }
+    return lastExtIdx;
+  }
+
+  function toExternalMatch(match) {
+    // Convert all the utf-8 Buffers into utf-16 strings.
+    match.input = str;
+    for (let i = 0; i < match.length; i++) {
+      if (match[i]) match[i] = match[i].toString('utf-8');
+    }
+    if (match.groups) {
+      for (const name of Object.keys(match.groups)) {
+        if (match.groups[name]) match.groups[name] = match.groups[name].toString('utf-8');
+      }
+    }
+
+    // Convert all the utf-8 indices into utf-16 indices.
+    // To use the index converter efficiently, go from least to greatest index.
+    const toConvert = [match.index];
+    if (match.indices) {
+      for (const xs of match.indices) {
+        if (xs) toConvert.push(xs[0], xs[1]);
+      }
+      if (match.indices.groups) {
+        for (const xs of Object.values(match.indices.groups)) {
+          if (xs) toConvert.push(xs[0], xs[1]);
+        }
+      }
+    }
+    toConvert.sort();
+
+    const converted = new Map();
+    for (const idx of toConvert) {
+      if (!converted.has(idx)) converted.set(idx, toExternalIndex(idx));
+    }
+
+    match.index = converted.get(match.index);
+    if (match.indices) {
+      for (const xs of match.indices) {
+        if (xs) {
+          xs[0] = converted.get(xs[0]);
+          xs[1] = converted.get(xs[1]);  
+        }
+      }
+      if (match.indices.groups) {
+        for (const xs of Object.values(match.indices.groups)) {
+          if (xs) {
+            xs[0] = converted.get(xs[0]);
+            xs[1] = converted.get(xs[1]);  
+          }
+        }
+      }
+    }
+
+    return match;
+  }
+
+  return { buf, toInternalIndex, toInternalReplacer, toExternalIndex, toExternalMatch };
 }
 
 module.exports = RE2;


### PR DESCRIPTION
This should fix #194. It's not complete in that it does not include sufficient comments, testing, or benchmarking (beyond confirming that it fixes the scaling issue). But I want to check that this is the approach you'd prefer. There is very little change to C++ code, but the JS changes are fairly involved, and it's a very bolt-on-wrapper kind of solution. 

There is presumably a certain amount of overhead for small inputs that didn't have scaling problems, due to the extra JS overhead. Doing the changes in C++ instead might avoid that. But I have not benchmarked it. I also don't know whether using the C++ `getUtf16Length` as I am is faster or slower than doing the same logic in JS.

In theory after these changes the C++ `replace` function could be simplified to only deal with buffer/UTF-8 inputs and outputs, since JS is handling the conversion.

Note that even with these changes, the scaling issue in #194 still exists for hand-written `exec` loops. That would be a much harder problem to solve. I think it would involve keeping state. And even with that, you'd still have to somehow be able to tell whether the input string to `exec` is the same string as before, preferably without holding a strong reference to the string.