### PR TITLE
Remove files used for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,13 @@
   "type": "commonjs",
   "main": "re2.js",
   "types": "re2.d.ts",
+  "files": [
+    "binding.gyp",
+    "lib",
+    "re2.d.ts",
+    "scripts",
+    "vendor"
+  ],
   "dependencies": {
     "install-artifact-from-github": "^1.3.5",
     "nan": "^2.18.0",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
   "type": "commonjs",
   "main": "re2.js",
   "types": "re2.d.ts",
-  "directories": {
-    "test": "tests"
-  },
   "dependencies": {
     "install-artifact-from-github": "^1.3.5",
     "nan": "^2.18.0",


### PR DESCRIPTION
I have removed files used for development from the package.
The differences in packaging are as follows.
```diff
@@ -1,30 +1,6 @@
 npm notice 
 npm notice 📦  re2@1.20.9
 npm notice === Tarball Contents === 
-npm notice 198B    .editorconfig                                                                               
-npm notice 225B    .github/actions/linux-alpine-node-18/action.yml                                             
-npm notice 144B    .github/actions/linux-alpine-node-18/Dockerfile                                             
-npm notice 152B    .github/actions/linux-alpine-node-18/entrypoint.sh                                          
-npm notice 225B    .github/actions/linux-alpine-node-20/action.yml                                             
-npm notice 144B    .github/actions/linux-alpine-node-20/Dockerfile                                             
-npm notice 152B    .github/actions/linux-alpine-node-20/entrypoint.sh                                          
-npm notice 225B    .github/actions/linux-alpine-node-21/action.yml                                             
-npm notice 144B    .github/actions/linux-alpine-node-21/Dockerfile                                             
-npm notice 152B    .github/actions/linux-alpine-node-21/entrypoint.sh                                          
-npm notice 324B    .github/actions/linux-node-18/action.yml                                                    
-npm notice 123B    .github/actions/linux-node-18/Dockerfile                                                    
-npm notice 152B    .github/actions/linux-node-18/entrypoint.sh                                                 
-npm notice 318B    .github/actions/linux-node-20/action.yml                                                    
-npm notice 123B    .github/actions/linux-node-20/Dockerfile                                                    
-npm notice 152B    .github/actions/linux-node-20/entrypoint.sh                                                 
-npm notice 320B    .github/actions/linux-node-21/action.yml                                                    
-npm notice 125B    .github/actions/linux-node-21/Dockerfile                                                    
-npm notice 152B    .github/actions/linux-node-21/entrypoint.sh                                                 
-npm notice 502B    .github/dependabot.yml                                                                      
-npm notice 3.5kB   .github/workflows/build.yml                                                                 
-npm notice 741B    .github/workflows/tests.yml                                                                 
-npm notice 183B    .gitmodules                                                                                 
-npm notice 126B    .prettierrc                                                                                 
 npm notice 1.9kB   LICENSE                                                                                     
 npm notice 19.7kB  README.md                                                                                   
 npm notice 6.5kB   binding.gyp                                                                                 
@@ -45,25 +21,6 @@
 npm notice 1.4kB   re2.d.ts                                                                                    
 npm notice 1.0kB   re2.js                                                                                      
 npm notice 357B    scripts/verify-build.js                                                                     
-npm notice 12.2kB  tests/test_exec.js                                                                          
-npm notice 7.3kB   tests/test_general.js                                                                       
-npm notice 2.8kB   tests/test_groups.js                                                                        
-npm notice 883B    tests/test_invalid.js                                                                       
-npm notice 4.3kB   tests/test_match.js                                                                         
-npm notice 2.5kB   tests/test_matchAll.js                                                                      
-npm notice 1.3kB   tests/test_new.js                                                                           
-npm notice 606B    tests/test_prototype.js                                                                     
-npm notice 11.5kB  tests/test_replace.js                                                                       
-npm notice 2.2kB   tests/test_search.js                                                                        
-npm notice 2.0kB   tests/test_source.js                                                                        
-npm notice 5.4kB   tests/test_split.js                                                                         
-npm notice 2.9kB   tests/test_symbols.js                                                                       
-npm notice 5.6kB   tests/test_test.js                                                                          
-npm notice 1.1kB   tests/test_toString.js                                                                      
-npm notice 455B    tests/tests.js                                                                              
-npm notice 754B    tests/worker.js                                                                             
-npm notice 855B    ts-tests/test-types.ts                                                                      
-npm notice 544B    tsconfig.json                                                                               
 npm notice 51B     vendor/abseil-cpp/.clang-format
 npm notice 2.0kB   vendor/abseil-cpp/.github/ISSUE_TEMPLATE/00-bug_report.yml
 npm notice 175B    vendor/abseil-cpp/.github/ISSUE_TEMPLATE/config.yml
@@ -1712,9 +1669,9 @@
 npm notice name:          re2
 npm notice version:       1.20.9
 npm notice filename:      re2-1.20.9.tgz
-npm notice package size:  2.6 MB                                  
+npm notice package size:  2.5 MB                                  
 npm notice unpacked size: 11.7 MB
-npm notice shasum:        3e6e5b73cdd911cdbdfe5133cc6670600e33871b
-npm notice integrity:     sha512-ZYcPTFr5ha2xq[...]VFqw1qoL3FMEQ==
-npm notice total files:   1707                                    
+npm notice shasum:        5d9e7ade86b189768467d882425a2d18879c1b92
+npm notice integrity:     sha512-BANSNCFwD59Qd[...]dMoCeU+DgOtkQ==
+npm notice total files:   1664 
```

And It seems that `directories.test` was unused and deleted.

https://docs.npmjs.com/cli/v6/configuring-npm/package-json#directoriestest
> **directories.test**
> Put your tests in here. It is currently not exposed, but it might be in the future.

https://docs.npmjs.com/cli/v7/configuring-npm/package-json#directories
