### PR TITLE
Add arm64 Linux prebuilds

### DIFF
--- a/.github/actions/linux-arm64-node-18/Dockerfile
+++ b/.github/actions/linux-arm64-node-18/Dockerfile
@@ -1,0 +1,6 @@
+FROM --platform=linux/arm64 node:18-buster
+
+RUN apt install python3 make gcc g++
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/linux-arm64-node-18/action.yml
+++ b/.github/actions/linux-arm64-node-18/action.yml
@@ -1,0 +1,12 @@
+name: 'Create a binary artifact for Node == 18 on Linux on ARM64'
+description: 'Create a binary artifact for Node == 18 on Linux on ARM64 using node:18-buster'
+inputs:
+  node-version:
+    description: 'Node.js version'
+    required: false
+    default: '18'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{inputs.node-version}}

--- a/.github/actions/linux-arm64-node-18/entrypoint.sh
+++ b/.github/actions/linux-arm64-node-18/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+export USERNAME=`whoami`
+export DEVELOPMENT_SKIP_GETTING_ASSET=true
+npm i
+npm run build --if-present
+npm test
+npm run save-to-github

--- a/.github/actions/linux-arm64-node-20/Dockerfile
+++ b/.github/actions/linux-arm64-node-20/Dockerfile
@@ -1,0 +1,6 @@
+FROM --platform=linux/arm64 node:20-buster
+
+RUN apt install python3 make gcc g++
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/linux-arm64-node-20/action.yml
+++ b/.github/actions/linux-arm64-node-20/action.yml
@@ -1,0 +1,12 @@
+name: 'Create a binary artifact for Node 20 on Linux on ARM64'
+description: 'Create a binary artifact for Node 20 on Linux on ARM64 using node:20-buster'
+inputs:
+  node-version:
+    description: 'Node.js version'
+    required: false
+    default: '20'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{inputs.node-version}}

--- a/.github/actions/linux-arm64-node-20/entrypoint.sh
+++ b/.github/actions/linux-arm64-node-20/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+export USERNAME=`whoami`
+export DEVELOPMENT_SKIP_GETTING_ASSET=true
+npm i
+npm run build --if-present
+npm test
+npm run save-to-github

--- a/.github/actions/linux-arm64-node-21/Dockerfile
+++ b/.github/actions/linux-arm64-node-21/Dockerfile
@@ -1,0 +1,6 @@
+FROM --platform=linux/arm64 node:21-bullseye
+
+RUN apt install python3 make gcc g++
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/linux-arm64-node-21/action.yml
+++ b/.github/actions/linux-arm64-node-21/action.yml
@@ -1,0 +1,12 @@
+name: 'Create a binary artifact for Node 21 on Linux on ARM64'
+description: 'Create a binary artifact for Node 21 on Linux on ARM64 using node:21-bullseye'
+inputs:
+  node-version:
+    description: 'Node.js version'
+    required: false
+    default: '21'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{inputs.node-version}}

--- a/.github/actions/linux-arm64-node-21/entrypoint.sh
+++ b/.github/actions/linux-arm64-node-21/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+export USERNAME=`whoami`
+export DEVELOPMENT_SKIP_GETTING_ASSET=true
+npm i
+npm run build --if-present
+npm test
+npm run save-to-github

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,3 +159,41 @@ jobs:
       uses: ./.github/actions/linux-arm64-node-18/
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+  build-linux-arm64-node-20:
+    name: Node.js 20 on Debian Buster on ARM64
+    needs: create-release
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: arm64
+    - name: Install, test, and create artifact
+      uses: ./.github/actions/linux-arm64-node-20/
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+  build-linux-arm64-node-21:
+    name: Node.js 21 on Debian Buster on ARM64
+    needs: create-release
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: arm64
+    - name: Install, test, and create artifact
+      uses: ./.github/actions/linux-arm64-node-21/
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,3 +140,22 @@ jobs:
       uses: ./.github/actions/linux-alpine-node-21/
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+  build-linux-arm64-node-18:
+    name: Node.js 18 on Debian Buster on ARM64
+    needs: create-release
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: arm64
+    - name: Install, test, and create artifact
+      uses: ./.github/actions/linux-arm64-node-18/
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
- Should resolve #193 
- Takes the simple approach of just using qemu and running docker on `linux/arm64` means that maintenance should be easy at the cost of the build taking around 30 mins for the arm prebuilds compared to 5 mins for the x86 as seen here https://github.com/heydovetail/node-re2/actions/runs/7483714804
- Once GitHub releases its arm runners we should be able to delete the qemu install and run it directly with docker on the runner with no emulation slow downs.