### PR TITLE
fix: remove npm from install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "node tests/tests.js",
     "ts-test": "tsc",
     "save-to-github": "save-to-github-cache --artifact build/Release/re2.node",
-    "install": "install-from-cache --artifact build/Release/re2.node --host-var RE2_DOWNLOAD_MIRROR --skip-path-var RE2_DOWNLOAD_SKIP_PATH --skip-ver-var RE2_DOWNLOAD_SKIP_VER || npm run rebuild",
+    "install": "install-from-cache --artifact build/Release/re2.node --host-var RE2_DOWNLOAD_MIRROR --skip-path-var RE2_DOWNLOAD_SKIP_PATH --skip-ver-var RE2_DOWNLOAD_SKIP_VER || node-gyp rebuild",
     "verify-build": "node scripts/verify-build.js",
     "rebuild": "node-gyp rebuild"
   },


### PR DESCRIPTION
The `install` script will fail when using a package manager other than npm (such as yarn or pnpm) through [corepack](https://nodejs.org/api/corepack.html).

```
Usage Error: This project is configured to use pnpm
```

It will also fail in the case when npm is not installed at all.

```
zsh: command not found: npm
```

This change should also be a tiny bit faster since it invokes node-gyp directly instead of relying on npm to invoke it.