### PR TITLE
Support Node.js v22

### DIFF
--- a/.github/actions/linux-alpine-node-22/Dockerfile
+++ b/.github/actions/linux-alpine-node-22/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:22-alpine
+
+RUN apk add --no-cache python3 make gcc g++ linux-headers
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/linux-alpine-node-22/action.yml
+++ b/.github/actions/linux-alpine-node-22/action.yml
@@ -1,0 +1,7 @@
+name: 'Create a binary artifact for Node 22 on Alpine Linux'
+description: 'Create a binary artifact for Node 22 on Alpine Linux using musl'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{inputs.node-version}}

--- a/.github/actions/linux-alpine-node-22/entrypoint.sh
+++ b/.github/actions/linux-alpine-node-22/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+export USERNAME=`whoami`
+export DEVELOPMENT_SKIP_GETTING_ASSET=true
+npm i
+npm run build --if-present
+npm test
+npm run save-to-github

--- a/.github/actions/linux-arm64-node-22/Dockerfile
+++ b/.github/actions/linux-arm64-node-22/Dockerfile
@@ -1,0 +1,6 @@
+FROM --platform=linux/arm64 node:22-bullseye
+
+RUN apt install python3 make gcc g++
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/linux-arm64-node-22/action.yml
+++ b/.github/actions/linux-arm64-node-22/action.yml
@@ -1,0 +1,12 @@
+name: 'Create a binary artifact for Node 22 on Linux on ARM64'
+description: 'Create a binary artifact for Node 22 on Linux on ARM64 using node:22-bullseye'
+inputs:
+  node-version:
+    description: 'Node.js version'
+    required: false
+    default: '22'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{inputs.node-version}}

--- a/.github/actions/linux-arm64-node-22/entrypoint.sh
+++ b/.github/actions/linux-arm64-node-22/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+export USERNAME=`whoami`
+export DEVELOPMENT_SKIP_GETTING_ASSET=true
+npm i
+npm run build --if-present
+npm test
+npm run save-to-github

--- a/.github/actions/linux-node-22/Dockerfile
+++ b/.github/actions/linux-node-22/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:22-bullseye
+
+RUN apt install python3 make gcc g++
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/linux-node-22/action.yml
+++ b/.github/actions/linux-node-22/action.yml
@@ -1,0 +1,12 @@
+name: 'Create a binary artifact for Node 22 on Linux'
+description: 'Create a binary artifact for Node 22 on Linux using node:22-bullseye'
+inputs:
+  node-version:
+    description: 'Node.js version'
+    required: false
+    default: '22'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{inputs.node-version}}

--- a/.github/actions/linux-node-22/entrypoint.sh
+++ b/.github/actions/linux-node-22/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+export USERNAME=`whoami`
+export DEVELOPMENT_SKIP_GETTING_ASSET=true
+npm i
+npm run build --if-present
+npm test
+npm run save-to-github

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, windows-latest]
-        node-version: [18, 20, 21]
+        node-version: [18, 20, 21, 22]
 
     steps:
     - uses: actions/checkout@v4
@@ -96,6 +96,21 @@ jobs:
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
+  build-linux-node-22:
+    name: Node.js 22 on Debian Bullseye
+    needs: create-release
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - name: Install, test, and create artifact
+      uses: ./.github/actions/linux-node-22/
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
   build-linux-alpine-node-18:
     name: Node.js 18 on Alpine Linux
     needs: create-release
@@ -138,6 +153,21 @@ jobs:
         submodules: true
     - name: Install, test, and create artifact
       uses: ./.github/actions/linux-alpine-node-21/
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+  build-linux-alpine-node-22:
+    name: Node.js 22 on Alpine Linux
+    needs: create-release
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - name: Install, test, and create artifact
+      uses: ./.github/actions/linux-alpine-node-22/
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
@@ -195,5 +225,24 @@ jobs:
         platforms: arm64
     - name: Install, test, and create artifact
       uses: ./.github/actions/linux-arm64-node-21/
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+  build-linux-arm64-node-22:
+    name: Node.js 22 on Debian Bullseye on ARM64
+    needs: create-release
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: arm64
+    - name: Install, test, and create artifact
+      uses: ./.github/actions/linux-arm64-node-22/
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "install-artifact-from-github": "^1.3.5",
-        "nan": "^2.18.0",
+        "nan": "^2.19.0",
         "node-gyp": "^10.0.1"
       },
       "devDependencies": {
@@ -669,9 +669,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nan": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
-      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
+      "integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw=="
     },
     "node_modules/negotiator": {
       "version": "0.6.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "install-artifact-from-github": "^1.3.5",
-    "nan": "^2.18.0",
+    "nan": "^2.19.0",
     "node-gyp": "^10.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
* A bump to nan is required since Node.js v22 uses V8 12.4. https://github.com/nodejs/nan/commit/1b630ddb3412cde35b64513662b440f9fd71e1ff is the relevant change.
* Add workflows and actions to build binaries for Node.js v22.