### PR TITLE
refactor(build.yml): deduplicate Linux build jobs with static-action matrices

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
           subject-name: '${{ env.CREATED_ASSET_NAME }}'
           subject-path: '${{ github.workspace }}/build/Release/re2.node'
 
-  build-linux:
+  build-linux-node-22:
     name: ${{ matrix.name }}
     needs: create-release
     runs-on: ${{ matrix.runs-on }}
@@ -70,52 +70,162 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Node.js 22
           - name: Node.js 22 on Bullseye
             runs-on: ubuntu-latest
-            action: ./.github/actions/linux-node-22/
           - name: Node.js 22 on Bullseye ARM64
             runs-on: ubuntu-24.04-arm
-            action: ./.github/actions/linux-node-22/
-          - name: Node.js 22 on Alpine
-            runs-on: ubuntu-latest
-            action: ./.github/actions/linux-alpine-node-22/
-          - name: Node.js 22 on Alpine ARM64
-            runs-on: ubuntu-24.04-arm
-            action: ./.github/actions/linux-alpine-node-22/
-          # Node.js 24
-          - name: Node.js 24 on Bullseye
-            runs-on: ubuntu-latest
-            action: ./.github/actions/linux-node-24/
-          - name: Node.js 24 on Bullseye ARM64
-            runs-on: ubuntu-24.04-arm
-            action: ./.github/actions/linux-node-24/
-          - name: Node.js 24 on Alpine
-            runs-on: ubuntu-latest
-            action: ./.github/actions/linux-alpine-node-24/
-          - name: Node.js 24 on Alpine ARM64
-            runs-on: ubuntu-24.04-arm
-            action: ./.github/actions/linux-alpine-node-24/
-          # Node.js 26
-          - name: Node.js 26 on Trixie
-            runs-on: ubuntu-latest
-            action: ./.github/actions/linux-node-26/
-          - name: Node.js 26 on Trixie ARM64
-            runs-on: ubuntu-24.04-arm
-            action: ./.github/actions/linux-node-26/
-          - name: Node.js 26 on Alpine
-            runs-on: ubuntu-latest
-            action: ./.github/actions/linux-alpine-node-26/
-          - name: Node.js 26 on Alpine ARM64
-            runs-on: ubuntu-24.04-arm
-            action: ./.github/actions/linux-alpine-node-26/
 
     steps:
       - uses: actions/checkout@v7
         with:
           submodules: true
       - name: Install, test, and create artifact
-        uses: ${{ matrix.action }}
+        uses: ./.github/actions/linux-node-22/
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Attest
+        if: env.CREATED_ASSET_NAME != ''
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: '${{ env.CREATED_ASSET_NAME }}'
+          subject-path: '${{ github.workspace }}/build/Release/re2.node'
+
+  build-linux-alpine-node-22:
+    name: ${{ matrix.name }}
+    needs: create-release
+    runs-on: ${{ matrix.runs-on }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Node.js 22 on Alpine
+            runs-on: ubuntu-latest
+          - name: Node.js 22 on Alpine ARM64
+            runs-on: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+      - name: Install, test, and create artifact
+        uses: ./.github/actions/linux-alpine-node-22/
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Attest
+        if: env.CREATED_ASSET_NAME != ''
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: '${{ env.CREATED_ASSET_NAME }}'
+          subject-path: '${{ github.workspace }}/build/Release/re2.node'
+
+  build-linux-node-24:
+    name: ${{ matrix.name }}
+    needs: create-release
+    runs-on: ${{ matrix.runs-on }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Node.js 24 on Bullseye
+            runs-on: ubuntu-latest
+          - name: Node.js 24 on Bullseye ARM64
+            runs-on: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+      - name: Install, test, and create artifact
+        uses: ./.github/actions/linux-node-24/
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Attest
+        if: env.CREATED_ASSET_NAME != ''
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: '${{ env.CREATED_ASSET_NAME }}'
+          subject-path: '${{ github.workspace }}/build/Release/re2.node'
+
+  build-linux-alpine-node-24:
+    name: ${{ matrix.name }}
+    needs: create-release
+    runs-on: ${{ matrix.runs-on }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Node.js 24 on Alpine
+            runs-on: ubuntu-latest
+          - name: Node.js 24 on Alpine ARM64
+            runs-on: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+      - name: Install, test, and create artifact
+        uses: ./.github/actions/linux-alpine-node-24/
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Attest
+        if: env.CREATED_ASSET_NAME != ''
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: '${{ env.CREATED_ASSET_NAME }}'
+          subject-path: '${{ github.workspace }}/build/Release/re2.node'
+
+  build-linux-node-26:
+    name: ${{ matrix.name }}
+    needs: create-release
+    runs-on: ${{ matrix.runs-on }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Node.js 26 on Trixie
+            runs-on: ubuntu-latest
+          - name: Node.js 26 on Trixie ARM64
+            runs-on: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+      - name: Install, test, and create artifact
+        uses: ./.github/actions/linux-node-26/
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Attest
+        if: env.CREATED_ASSET_NAME != ''
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: '${{ env.CREATED_ASSET_NAME }}'
+          subject-path: '${{ github.workspace }}/build/Release/re2.node'
+
+  build-linux-alpine-node-26:
+    name: ${{ matrix.name }}
+    needs: create-release
+    runs-on: ${{ matrix.runs-on }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Node.js 26 on Alpine
+            runs-on: ubuntu-latest
+          - name: Node.js 26 on Alpine ARM64
+            runs-on: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+      - name: Install, test, and create artifact
+        uses: ./.github/actions/linux-alpine-node-26/
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Attest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,249 +61,61 @@ jobs:
           subject-name: '${{ env.CREATED_ASSET_NAME }}'
           subject-path: '${{ github.workspace }}/build/Release/re2.node'
 
-  build-linux-node-22:
-    name: Node.js 22 on Bullseye
+  build-linux:
+    name: ${{ matrix.name }}
     needs: create-release
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
     continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Node.js 22
+          - name: Node.js 22 on Bullseye
+            runs-on: ubuntu-latest
+            action: ./.github/actions/linux-node-22/
+          - name: Node.js 22 on Bullseye ARM64
+            runs-on: ubuntu-24.04-arm
+            action: ./.github/actions/linux-node-22/
+          - name: Node.js 22 on Alpine
+            runs-on: ubuntu-latest
+            action: ./.github/actions/linux-alpine-node-22/
+          - name: Node.js 22 on Alpine ARM64
+            runs-on: ubuntu-24.04-arm
+            action: ./.github/actions/linux-alpine-node-22/
+          # Node.js 24
+          - name: Node.js 24 on Bullseye
+            runs-on: ubuntu-latest
+            action: ./.github/actions/linux-node-24/
+          - name: Node.js 24 on Bullseye ARM64
+            runs-on: ubuntu-24.04-arm
+            action: ./.github/actions/linux-node-24/
+          - name: Node.js 24 on Alpine
+            runs-on: ubuntu-latest
+            action: ./.github/actions/linux-alpine-node-24/
+          - name: Node.js 24 on Alpine ARM64
+            runs-on: ubuntu-24.04-arm
+            action: ./.github/actions/linux-alpine-node-24/
+          # Node.js 26
+          - name: Node.js 26 on Trixie
+            runs-on: ubuntu-latest
+            action: ./.github/actions/linux-node-26/
+          - name: Node.js 26 on Trixie ARM64
+            runs-on: ubuntu-24.04-arm
+            action: ./.github/actions/linux-node-26/
+          - name: Node.js 26 on Alpine
+            runs-on: ubuntu-latest
+            action: ./.github/actions/linux-alpine-node-26/
+          - name: Node.js 26 on Alpine ARM64
+            runs-on: ubuntu-24.04-arm
+            action: ./.github/actions/linux-alpine-node-26/
 
     steps:
       - uses: actions/checkout@v7
         with:
           submodules: true
       - name: Install, test, and create artifact
-        uses: ./.github/actions/linux-node-22/
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Attest
-        if: env.CREATED_ASSET_NAME != ''
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-name: '${{ env.CREATED_ASSET_NAME }}'
-          subject-path: '${{ github.workspace }}/build/Release/re2.node'
-
-  build-linux-alpine-node-22:
-    name: Node.js 22 on Alpine
-    needs: create-release
-    runs-on: ubuntu-latest
-    continue-on-error: true
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          submodules: true
-      - name: Install, test, and create artifact
-        uses: ./.github/actions/linux-alpine-node-22/
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Attest
-        if: env.CREATED_ASSET_NAME != ''
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-name: '${{ env.CREATED_ASSET_NAME }}'
-          subject-path: '${{ github.workspace }}/build/Release/re2.node'
-
-  build-linux-arm64-node-22:
-    name: Node.js 22 on Bullseye ARM64
-    needs: create-release
-    runs-on: ubuntu-24.04-arm
-    continue-on-error: true
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          submodules: true
-      - name: Install, test, and create artifact
-        uses: ./.github/actions/linux-node-22/
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Attest
-        if: env.CREATED_ASSET_NAME != ''
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-name: '${{ env.CREATED_ASSET_NAME }}'
-          subject-path: '${{ github.workspace }}/build/Release/re2.node'
-
-  build-linux-arm64-alpine-node-22:
-    name: Node.js 22 on Alpine ARM64
-    needs: create-release
-    runs-on: ubuntu-24.04-arm
-    continue-on-error: true
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          submodules: true
-      - name: Install, test, and create artifact
-        uses: ./.github/actions/linux-alpine-node-22/
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Attest
-        if: env.CREATED_ASSET_NAME != ''
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-name: '${{ env.CREATED_ASSET_NAME }}'
-          subject-path: '${{ github.workspace }}/build/Release/re2.node'
-
-  build-linux-node-24:
-    name: Node.js 24 on Bullseye
-    needs: create-release
-    runs-on: ubuntu-latest
-    continue-on-error: true
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          submodules: true
-      - name: Install, test, and create artifact
-        uses: ./.github/actions/linux-node-24/
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Attest
-        if: env.CREATED_ASSET_NAME != ''
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-name: '${{ env.CREATED_ASSET_NAME }}'
-          subject-path: '${{ github.workspace }}/build/Release/re2.node'
-
-  build-linux-alpine-node-24:
-    name: Node.js 24 on Alpine
-    needs: create-release
-    runs-on: ubuntu-latest
-    continue-on-error: true
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          submodules: true
-      - name: Install, test, and create artifact
-        uses: ./.github/actions/linux-alpine-node-24/
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Attest
-        if: env.CREATED_ASSET_NAME != ''
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-name: '${{ env.CREATED_ASSET_NAME }}'
-          subject-path: '${{ github.workspace }}/build/Release/re2.node'
-
-  build-linux-arm64-node-24:
-    name: Node.js 24 on Bullseye ARM64
-    needs: create-release
-    runs-on: ubuntu-24.04-arm
-    continue-on-error: true
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          submodules: true
-      - name: Install, test, and create artifact
-        uses: ./.github/actions/linux-node-24/
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Attest
-        if: env.CREATED_ASSET_NAME != ''
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-name: '${{ env.CREATED_ASSET_NAME }}'
-          subject-path: '${{ github.workspace }}/build/Release/re2.node'
-
-  build-linux-arm64-alpine-node-24:
-    name: Node.js 24 on Alpine ARM64
-    needs: create-release
-    runs-on: ubuntu-24.04-arm
-    continue-on-error: true
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          submodules: true
-      - name: Install, test, and create artifact
-        uses: ./.github/actions/linux-alpine-node-24/
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Attest
-        if: env.CREATED_ASSET_NAME != ''
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-name: '${{ env.CREATED_ASSET_NAME }}'
-          subject-path: '${{ github.workspace }}/build/Release/re2.node'
-
-  build-linux-node-26:
-    name: Node.js 26 on Trixie
-    needs: create-release
-    runs-on: ubuntu-latest
-    continue-on-error: true
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          submodules: true
-      - name: Install, test, and create artifact
-        uses: ./.github/actions/linux-node-26/
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Attest
-        if: env.CREATED_ASSET_NAME != ''
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-name: '${{ env.CREATED_ASSET_NAME }}'
-          subject-path: '${{ github.workspace }}/build/Release/re2.node'
-
-  build-linux-alpine-node-26:
-    name: Node.js 26 on Alpine
-    needs: create-release
-    runs-on: ubuntu-latest
-    continue-on-error: true
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          submodules: true
-      - name: Install, test, and create artifact
-        uses: ./.github/actions/linux-alpine-node-26/
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Attest
-        if: env.CREATED_ASSET_NAME != ''
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-name: '${{ env.CREATED_ASSET_NAME }}'
-          subject-path: '${{ github.workspace }}/build/Release/re2.node'
-
-  build-linux-arm64-node-26:
-    name: Node.js 26 on Trixie ARM64
-    needs: create-release
-    runs-on: ubuntu-24.04-arm
-    continue-on-error: true
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          submodules: true
-      - name: Install, test, and create artifact
-        uses: ./.github/actions/linux-node-26/
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Attest
-        if: env.CREATED_ASSET_NAME != ''
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-name: '${{ env.CREATED_ASSET_NAME }}'
-          subject-path: '${{ github.workspace }}/build/Release/re2.node'
-
-  build-linux-arm64-alpine-node-26:
-    name: Node.js 26 on Alpine ARM64
-    needs: create-release
-    runs-on: ubuntu-24.04-arm
-    continue-on-error: true
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          submodules: true
-      - name: Install, test, and create artifact
-        uses: ./.github/actions/linux-alpine-node-26/
+        uses: ${{ matrix.action }}
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Attest


### PR DESCRIPTION
Closes #266.

## Summary

`build.yml` currently defines 12 nearly identical Linux build jobs — one per Node.js/distro/architecture combination. This PR deduplicates them by grouping each static local action into a small matrix over the runner architecture.

## Before

* 12 separate Linux job definitions with duplicated `steps` blocks
* Each x64/ARM64 pair duplicated the same local action and attestation steps

## After

* 6 Linux matrix jobs:

  * `linux-node-22`
  * `linux-alpine-node-22`
  * `linux-node-24`
  * `linux-alpine-node-24`
  * `linux-node-26`
  * `linux-alpine-node-26`
* Each job keeps a static `uses: ./.github/actions/...` reference
* Each job matrix only varies `name` and `runs-on`
* All 12 original Linux build combinations are preserved
* Added `fail-fast: false` so one platform failure does not cancel the other matrix entries

## Verification

* Static local action references are preserved; no dynamic `uses` expression is used
* All original Linux Node/distro/architecture combinations are still present
* Job display names are preserved
* Release artifact and attestation steps are preserved
